### PR TITLE
Partial fix for **Convert to Shape Group** line inversion; DrawKit#7

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,4 +4,5 @@ Individual Contributors
 Graham Cox <http://apptree.net/appcontact.htm>
 Graham Miln <graham.miln@miln.eu>
 Jason Jobe
+Mediajon <https://github.com/Mediajon>
 Stephan Zehrer <http://www.stephan-zehrer.de>

--- a/framework/Code/DKBezierLayoutManager.m
+++ b/framework/Code/DKBezierLayoutManager.m
@@ -1,9 +1,7 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
+ @author Contributions from the community; see CONTRIBUTORS
+ @date 2005-2015
+ @copyright This software is released subject to licensing conditions as detailed in LICENSE, which must accompany this source file.
  */
 
 #import "DKBezierLayoutManager.h"
@@ -55,7 +53,7 @@
 				ploc = gloc = [self locationForGlyphAtIndex:g];
 
 				ploc.x -= fragRect.origin.x;
-				ploc.y -= fragRect.origin.y;
+				ploc.y = fragRect.origin.y;
 
 				font = [[[self textStorage] attributesAtIndex:g
 											   effectiveRange:NULL] objectForKey:NSFontAttributeName];


### PR DESCRIPTION
Thanks to @Mediajon for finding and fixing this bug. A second bug remains within the **Convert to Shape Group** method but it is not affected by this fix.