### PR TITLE
Adding third party names to CONTRIBUTORS.md and updating copyright block

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,12 @@
 - Jason Jobe
 - [Mediajon](https://github.com/Mediajon)
 - [Stephan Zehrer](http://www.stephan-zehrer.de)
+
+## Third Party Code
+
+- [Intriguing Development](http://www.idevelop.net)
+- [Lauris Kaplinski](mailto:lauris@ximian.com)
+- [Michael G. Sloan](mailto:mgsloan@gmail.com)
+- [Nathan Hurst](mailto:njh@mail.csse.monash.edu.au)
+- [Omni Development, Inc](http://www.omnigroup.com/developer/sourcecode/sourcelicense/)
+- Philip J. Schneider

--- a/framework/Code/DKArcPath.h
+++ b/framework/Code/DKArcPath.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawablePath.h"
 

--- a/framework/Code/DKArcPath.m
+++ b/framework/Code/DKArcPath.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKArcPath.h"
 #import "DKDrawableShape.h"

--- a/framework/Code/DKArrowStroke.h
+++ b/framework/Code/DKArrowStroke.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStroke.h"
 

--- a/framework/Code/DKArrowStroke.m
+++ b/framework/Code/DKArrowStroke.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKArrowStroke.h"
 #import "DKStyle.h"

--- a/framework/Code/DKAuxiliaryMenus.h
+++ b/framework/Code/DKAuxiliaryMenus.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKAuxiliaryMenus.m
+++ b/framework/Code/DKAuxiliaryMenus.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKAuxiliaryMenus.h"
 

--- a/framework/Code/DKBSPDirectObjectStorage.h
+++ b/framework/Code/DKBSPDirectObjectStorage.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKBSPObjectStorage.h"

--- a/framework/Code/DKBSPDirectObjectStorage.m
+++ b/framework/Code/DKBSPDirectObjectStorage.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKBSPDirectObjectStorage.h"
 

--- a/framework/Code/DKBSPObjectStorage.h
+++ b/framework/Code/DKBSPObjectStorage.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKLinearObjectStorage.h"

--- a/framework/Code/DKBSPObjectStorage.m
+++ b/framework/Code/DKBSPObjectStorage.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKBSPObjectStorage.h"
 #import "LogEvent.h"

--- a/framework/Code/DKBezierLayoutManager.h
+++ b/framework/Code/DKBezierLayoutManager.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKBezierLayoutManager.m
+++ b/framework/Code/DKBezierLayoutManager.m
@@ -1,5 +1,5 @@
 /**
- @author Contributions from the community; see CONTRIBUTORS
+ @author Contributions from the community; see CONTRIBUTORS.md; see CONTRIBUTORS
  @date 2005-2015
  @copyright This software is released subject to licensing conditions as detailed in LICENSE, which must accompany this source file.
  */

--- a/framework/Code/DKBezierTextContainer.h
+++ b/framework/Code/DKBezierTextContainer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKBezierTextContainer.m
+++ b/framework/Code/DKBezierTextContainer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKBezierTextContainer.h"
 #import "NSBezierPath+Text.h"

--- a/framework/Code/DKBoundingRectHandle.h
+++ b/framework/Code/DKBoundingRectHandle.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKHandle.h"

--- a/framework/Code/DKBoundingRectHandle.m
+++ b/framework/Code/DKBoundingRectHandle.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKBoundingRectHandle.h"
 

--- a/framework/Code/DKCIFilterRastGroup.h
+++ b/framework/Code/DKCIFilterRastGroup.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRastGroup.h"
 

--- a/framework/Code/DKCIFilterRastGroup.m
+++ b/framework/Code/DKCIFilterRastGroup.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKCIFilterRastGroup.h"
 

--- a/framework/Code/DKCategoryManager.h
+++ b/framework/Code/DKCategoryManager.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKCategoryManager.m
+++ b/framework/Code/DKCategoryManager.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKCategoryManager.h"
 #import "NSDictionary+DeepCopy.h"

--- a/framework/Code/DKColourQuantizer.h
+++ b/framework/Code/DKColourQuantizer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKColourQuantizer.m
+++ b/framework/Code/DKColourQuantizer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKColourQuantizer.h"
 

--- a/framework/Code/DKCommonTypes.h
+++ b/framework/Code/DKCommonTypes.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 // functional types, as passed to drawKnobAtPoint:ofType:userInfo:
 // locked flag can be ORed in to pass signal the locked property - any other state info used by subclasses

--- a/framework/Code/DKCropTool.h
+++ b/framework/Code/DKCropTool.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingTool.h"
 

--- a/framework/Code/DKCropTool.m
+++ b/framework/Code/DKCropTool.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKCropTool.h"
 #import "DKObjectDrawingLayer.h"

--- a/framework/Code/DKDistortionTransform.h
+++ b/framework/Code/DKDistortionTransform.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKDistortionTransform.mm
+++ b/framework/Code/DKDistortionTransform.mm
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDistortionTransform.h"
 

--- a/framework/Code/DKDrawKit.h
+++ b/framework/Code/DKDrawKit.h
@@ -1,10 +1,7 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- @licence LGPL3
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE @licence LGPL3
  */
 
 #import "DKDrawingView.h"

--- a/framework/Code/DKDrawKitMacros.h
+++ b/framework/Code/DKDrawKitMacros.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 //#import <Cocoa/Cocoa.h>
 #include <tgmath.h>

--- a/framework/Code/DKDrawKit_Prefix.pch
+++ b/framework/Code/DKDrawKit_Prefix.pch
@@ -1,10 +1,7 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- Prefix header for all source files of the 'DrawKit' target in the 'DrawKit' project. */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE Prefix header for all source files of the 'DrawKit' target in the 'DrawKit' project. */
 
 #ifndef qDebug
 #define NS_BLOCK_ASSERTIONS

--- a/framework/Code/DKDrawableContainerProtocol.h
+++ b/framework/Code/DKDrawableContainerProtocol.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKDrawableObject+Metadata.h
+++ b/framework/Code/DKDrawableObject+Metadata.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableObject.h"
 #import "DKMetadataItem.h"

--- a/framework/Code/DKDrawableObject+Metadata.m
+++ b/framework/Code/DKDrawableObject+Metadata.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableObject+Metadata.h"
 #import "DKUndoManager.h"

--- a/framework/Code/DKDrawableObject.h
+++ b/framework/Code/DKDrawableObject.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKCommonTypes.h"

--- a/framework/Code/DKDrawableObject.m
+++ b/framework/Code/DKDrawableObject.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableObject.h"
 #import "DKDrawing.h"

--- a/framework/Code/DKDrawablePath.h
+++ b/framework/Code/DKDrawablePath.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableObject.h"
 

--- a/framework/Code/DKDrawablePath.m
+++ b/framework/Code/DKDrawablePath.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawablePath.h"
 #import "DKShapeGroup.h"

--- a/framework/Code/DKDrawableShape+Hotspots.h
+++ b/framework/Code/DKDrawableShape+Hotspots.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape.h"
 

--- a/framework/Code/DKDrawableShape+Hotspots.m
+++ b/framework/Code/DKDrawableShape+Hotspots.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape+Hotspots.h"
 

--- a/framework/Code/DKDrawableShape+Utilities.h
+++ b/framework/Code/DKDrawableShape+Utilities.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKDrawableShape.h"

--- a/framework/Code/DKDrawableShape+Utilities.m
+++ b/framework/Code/DKDrawableShape+Utilities.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape+Utilities.h"
 

--- a/framework/Code/DKDrawableShape.h
+++ b/framework/Code/DKDrawableShape.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableObject.h"
 

--- a/framework/Code/DKDrawableShape.m
+++ b/framework/Code/DKDrawableShape.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape.h"
 #import "DKDrawablePath.h"

--- a/framework/Code/DKDrawing+Export.h
+++ b/framework/Code/DKDrawing+Export.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawing.h"
 

--- a/framework/Code/DKDrawing+Export.m
+++ b/framework/Code/DKDrawing+Export.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawing+Export.h"
 #import "DKLayer+Metadata.h"

--- a/framework/Code/DKDrawing+Paper.h
+++ b/framework/Code/DKDrawing+Paper.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKDrawing.h"

--- a/framework/Code/DKDrawing+Paper.m
+++ b/framework/Code/DKDrawing+Paper.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawing+Paper.h"
 

--- a/framework/Code/DKDrawing.h
+++ b/framework/Code/DKDrawing.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayerGroup.h"
 

--- a/framework/Code/DKDrawing.m
+++ b/framework/Code/DKDrawing.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawing.h"
 #import "DKDrawing+Paper.h"

--- a/framework/Code/DKDrawingDocument.h
+++ b/framework/Code/DKDrawingDocument.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKDrawingDocument.m
+++ b/framework/Code/DKDrawingDocument.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingDocument.h"
 #import "DKUndoManager.h"

--- a/framework/Code/DKDrawingInfoLayer.h
+++ b/framework/Code/DKDrawingInfoLayer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 

--- a/framework/Code/DKDrawingInfoLayer.m
+++ b/framework/Code/DKDrawingInfoLayer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingInfoLayer.h"
 

--- a/framework/Code/DKDrawingTool.h
+++ b/framework/Code/DKDrawingTool.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingToolProtocol.h"
 

--- a/framework/Code/DKDrawingTool.m
+++ b/framework/Code/DKDrawingTool.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectCreationTool.h"
 #import "DKLayer.h"

--- a/framework/Code/DKDrawingToolProtocol.h
+++ b/framework/Code/DKDrawingToolProtocol.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKDrawingView+Drop.h
+++ b/framework/Code/DKDrawingView+Drop.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingView.h"
 

--- a/framework/Code/DKDrawingView+Drop.m
+++ b/framework/Code/DKDrawingView+Drop.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingView+Drop.h"
 #import "DKObjectOwnerLayer.h"

--- a/framework/Code/DKDrawingView.h
+++ b/framework/Code/DKDrawingView.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCZoomView.h"
 

--- a/framework/Code/DKDrawingView.m
+++ b/framework/Code/DKDrawingView.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingView.h"
 #import "DKToolController.h"

--- a/framework/Code/DKDrawkitInspectorBase.h
+++ b/framework/Code/DKDrawkitInspectorBase.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKDrawkitInspectorBase.m
+++ b/framework/Code/DKDrawkitInspectorBase.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawkitInspectorBase.h"
 #import "DKDrawableObject.h"

--- a/framework/Code/DKFill.h
+++ b/framework/Code/DKFill.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 

--- a/framework/Code/DKFill.m
+++ b/framework/Code/DKFill.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKFill.h"
 #import "DKStyle.h"

--- a/framework/Code/DKFillPattern.h
+++ b/framework/Code/DKFillPattern.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKPathDecorator.h"
 

--- a/framework/Code/DKFillPattern.m
+++ b/framework/Code/DKFillPattern.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKFillPattern.h"
 #import "DKDrawKitMacros.h"

--- a/framework/Code/DKGeometryUtilities.h
+++ b/framework/Code/DKGeometryUtilities.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKGeometryUtilities.m
+++ b/framework/Code/DKGeometryUtilities.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGeometryUtilities.h"
 #import "NSBezierPath+Geometry.h"

--- a/framework/Code/DKGradient+UISupport.h
+++ b/framework/Code/DKGradient+UISupport.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKGradient.h"

--- a/framework/Code/DKGradient+UISupport.m
+++ b/framework/Code/DKGradient+UISupport.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGradient+UISupport.h"
 #include <tgmath.h>

--- a/framework/Code/DKGradient.h
+++ b/framework/Code/DKGradient.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCObservableObject.h"
 

--- a/framework/Code/DKGradient.m
+++ b/framework/Code/DKGradient.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGradient.h"
 

--- a/framework/Code/DKGradientExtensions.h
+++ b/framework/Code/DKGradientExtensions.h
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGradient.h"
 

--- a/framework/Code/DKGradientExtensions.m
+++ b/framework/Code/DKGradientExtensions.m
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Job
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGradientExtensions.h"
 

--- a/framework/Code/DKGreekingLayoutManager.h
+++ b/framework/Code/DKGreekingLayoutManager.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKCommonTypes.h"

--- a/framework/Code/DKGreekingLayoutManager.m
+++ b/framework/Code/DKGreekingLayoutManager.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGreekingLayoutManager.h"
 

--- a/framework/Code/DKGridLayer.h
+++ b/framework/Code/DKGridLayer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 

--- a/framework/Code/DKGridLayer.m
+++ b/framework/Code/DKGridLayer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGridLayer.h"
 #import "DKDrawing.h"

--- a/framework/Code/DKGuideLayer.h
+++ b/framework/Code/DKGuideLayer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 

--- a/framework/Code/DKGuideLayer.m
+++ b/framework/Code/DKGuideLayer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGuideLayer.h"
 #import "DKDrawingView.h"

--- a/framework/Code/DKHandle.h
+++ b/framework/Code/DKHandle.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKCommonTypes.h"

--- a/framework/Code/DKHandle.m
+++ b/framework/Code/DKHandle.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKHandle.h"
 #import "DKBoundingRectHandle.h"

--- a/framework/Code/DKHatching.h
+++ b/framework/Code/DKHatching.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 

--- a/framework/Code/DKHatching.m
+++ b/framework/Code/DKHatching.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKHatching.h"
 #import "DKDrawKitMacros.h"

--- a/framework/Code/DKImageAdornment.h
+++ b/framework/Code/DKImageAdornment.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 

--- a/framework/Code/DKImageAdornment.m
+++ b/framework/Code/DKImageAdornment.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKImageAdornment.h"
 #import "DKGeometryUtilities.h"

--- a/framework/Code/DKImageDataManager.h
+++ b/framework/Code/DKImageDataManager.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKImageDataManager.m
+++ b/framework/Code/DKImageDataManager.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKImageDataManager.h"
 #import "DKUniqueID.h"

--- a/framework/Code/DKImageOverlayLayer.h
+++ b/framework/Code/DKImageOverlayLayer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 

--- a/framework/Code/DKImageOverlayLayer.m
+++ b/framework/Code/DKImageOverlayLayer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKImageOverlayLayer.h"
 

--- a/framework/Code/DKImageShape.h
+++ b/framework/Code/DKImageShape.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape.h"
 

--- a/framework/Code/DKImageShape.m
+++ b/framework/Code/DKImageShape.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKImageShape.h"
 #import "DKObjectOwnerLayer.h"

--- a/framework/Code/DKKeyedUnarchiver.h
+++ b/framework/Code/DKKeyedUnarchiver.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKKeyedUnarchiver.m
+++ b/framework/Code/DKKeyedUnarchiver.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKKeyedUnarchiver.h"
 

--- a/framework/Code/DKKnob.h
+++ b/framework/Code/DKKnob.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKCommonTypes.h"

--- a/framework/Code/DKKnob.m
+++ b/framework/Code/DKKnob.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKKnob.h"
 #import "DKGeometryUtilities.h"

--- a/framework/Code/DKLayer+Metadata.h
+++ b/framework/Code/DKLayer+Metadata.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 #import "DKMetadataItem.h"

--- a/framework/Code/DKLayer+Metadata.m
+++ b/framework/Code/DKLayer+Metadata.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer+Metadata.h"
 #import "LogEvent.h"

--- a/framework/Code/DKLayer.h
+++ b/framework/Code/DKLayer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKCommonTypes.h"

--- a/framework/Code/DKLayer.m
+++ b/framework/Code/DKLayer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 #import "DKKnob.h"

--- a/framework/Code/DKLayerGroup.h
+++ b/framework/Code/DKLayerGroup.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 

--- a/framework/Code/DKLayerGroup.m
+++ b/framework/Code/DKLayerGroup.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayerGroup.h"
 #import "DKDrawing.h"

--- a/framework/Code/DKLinearObjectStorage.h
+++ b/framework/Code/DKLinearObjectStorage.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKObjectStorageProtocol.h"

--- a/framework/Code/DKLinearObjectStorage.m
+++ b/framework/Code/DKLinearObjectStorage.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLinearObjectStorage.h"
 #import "LogEvent.h"

--- a/framework/Code/DKMetadataItem.h
+++ b/framework/Code/DKMetadataItem.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKMetadataItem.m
+++ b/framework/Code/DKMetadataItem.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKMetadataItem.h"
 

--- a/framework/Code/DKObjectCreationTool.h
+++ b/framework/Code/DKObjectCreationTool.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingTool.h"
 

--- a/framework/Code/DKObjectCreationTool.m
+++ b/framework/Code/DKObjectCreationTool.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectCreationTool.h"
 #import "DKObjectDrawingLayer.h"

--- a/framework/Code/DKObjectDrawingLayer+Alignment.h
+++ b/framework/Code/DKObjectDrawingLayer+Alignment.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectDrawingLayer.h"
 

--- a/framework/Code/DKObjectDrawingLayer+Alignment.m
+++ b/framework/Code/DKObjectDrawingLayer+Alignment.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectDrawingLayer+Alignment.h"
 

--- a/framework/Code/DKObjectDrawingLayer+Duplication.h
+++ b/framework/Code/DKObjectDrawingLayer+Duplication.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectDrawingLayer.h"
 

--- a/framework/Code/DKObjectDrawingLayer+Duplication.m
+++ b/framework/Code/DKObjectDrawingLayer+Duplication.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectDrawingLayer+Duplication.h"
 

--- a/framework/Code/DKObjectDrawingLayer.h
+++ b/framework/Code/DKObjectDrawingLayer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectOwnerLayer.h"
 

--- a/framework/Code/DKObjectDrawingLayer.m
+++ b/framework/Code/DKObjectDrawingLayer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectDrawingLayer.h"
 #import "DKDrawablePath.h"

--- a/framework/Code/DKObjectOwnerLayer.h
+++ b/framework/Code/DKObjectOwnerLayer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKLayer.h"
 #import "DKObjectStorageProtocol.h"

--- a/framework/Code/DKObjectOwnerLayer.m
+++ b/framework/Code/DKObjectOwnerLayer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKObjectOwnerLayer.h"
 #import "DKLayer+Metadata.h"

--- a/framework/Code/DKObjectStorageProtocol.h
+++ b/framework/Code/DKObjectStorageProtocol.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKPasteboardInfo.h
+++ b/framework/Code/DKPasteboardInfo.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKPasteboardInfo.m
+++ b/framework/Code/DKPasteboardInfo.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKPasteboardInfo.h"
 #import "DKGeometryUtilities.h"

--- a/framework/Code/DKPathDecorator.h
+++ b/framework/Code/DKPathDecorator.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 

--- a/framework/Code/DKPathDecorator.m
+++ b/framework/Code/DKPathDecorator.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKPathDecorator.h"
 

--- a/framework/Code/DKPathInsertDeleteTool.h
+++ b/framework/Code/DKPathInsertDeleteTool.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingTool.h"
 

--- a/framework/Code/DKPathInsertDeleteTool.m
+++ b/framework/Code/DKPathInsertDeleteTool.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKPathInsertDeleteTool.h"
 

--- a/framework/Code/DKPathPointHandle.h
+++ b/framework/Code/DKPathPointHandle.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKHandle.h"

--- a/framework/Code/DKPathPointHandle.m
+++ b/framework/Code/DKPathPointHandle.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKPathPointHandle.h"
 

--- a/framework/Code/DKPrintDrawingView.h
+++ b/framework/Code/DKPrintDrawingView.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingView.h"
 

--- a/framework/Code/DKPrintDrawingView.m
+++ b/framework/Code/DKPrintDrawingView.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKPrintDrawingView.h"
 

--- a/framework/Code/DKQuartzBlendRastGroup.h
+++ b/framework/Code/DKQuartzBlendRastGroup.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRastGroup.h"
 

--- a/framework/Code/DKQuartzBlendRastGroup.m
+++ b/framework/Code/DKQuartzBlendRastGroup.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKQuartzBlendRastGroup.h"
 

--- a/framework/Code/DKQuartzCache.h
+++ b/framework/Code/DKQuartzCache.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKQuartzCache.m
+++ b/framework/Code/DKQuartzCache.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKQuartzCache.h"
 

--- a/framework/Code/DKRandom.h
+++ b/framework/Code/DKRandom.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKRandom.m
+++ b/framework/Code/DKRandom.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRandom.h"
 

--- a/framework/Code/DKRastGroup.h
+++ b/framework/Code/DKRastGroup.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 

--- a/framework/Code/DKRastGroup.m
+++ b/framework/Code/DKRastGroup.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRastGroup.h"
 #import "NSDictionary+DeepCopy.h"

--- a/framework/Code/DKRasterizer.h
+++ b/framework/Code/DKRasterizer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizerProtocol.h"
 #import "GCObservableObject.h"

--- a/framework/Code/DKRasterizer.m
+++ b/framework/Code/DKRasterizer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 #import "DKStyle.h"

--- a/framework/Code/DKRasterizerProtocol.h
+++ b/framework/Code/DKRasterizerProtocol.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKRegularPolygonPath.h
+++ b/framework/Code/DKRegularPolygonPath.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawablePath.h"
 

--- a/framework/Code/DKRegularPolygonPath.m
+++ b/framework/Code/DKRegularPolygonPath.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRegularPolygonPath.h"
 #import "DKDrawableShape.h"

--- a/framework/Code/DKReshapableShape.h
+++ b/framework/Code/DKReshapableShape.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape.h"
 

--- a/framework/Code/DKReshapableShape.m
+++ b/framework/Code/DKReshapableShape.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKReshapableShape.h"
 

--- a/framework/Code/DKRetriggerableTimer.h
+++ b/framework/Code/DKRetriggerableTimer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKRetriggerableTimer.m
+++ b/framework/Code/DKRetriggerableTimer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRetriggerableTimer.h"
 

--- a/framework/Code/DKRotationHandle.h
+++ b/framework/Code/DKRotationHandle.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKHandle.h"

--- a/framework/Code/DKRotationHandle.m
+++ b/framework/Code/DKRotationHandle.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRotationHandle.h"
 

--- a/framework/Code/DKRoughStroke.h
+++ b/framework/Code/DKRoughStroke.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStroke.h"
 

--- a/framework/Code/DKRoughStroke.m
+++ b/framework/Code/DKRoughStroke.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRoughStroke.h"
 #import "NSBezierPath+Geometry.h"

--- a/framework/Code/DKRouteFinder.h
+++ b/framework/Code/DKRouteFinder.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKRouteFinder.m
+++ b/framework/Code/DKRouteFinder.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRouteFinder.h"
 

--- a/framework/Code/DKRuntimeHelper.h
+++ b/framework/Code/DKRuntimeHelper.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKRuntimeHelper.m
+++ b/framework/Code/DKRuntimeHelper.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRuntimeHelper.h"
 

--- a/framework/Code/DKSelectAndEditTool.h
+++ b/framework/Code/DKSelectAndEditTool.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingTool.h"
 #import "DKRasterizerProtocol.h"

--- a/framework/Code/DKSelectAndEditTool.m
+++ b/framework/Code/DKSelectAndEditTool.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKSelectAndEditTool.h"
 #import "DKObjectDrawingLayer.h"

--- a/framework/Code/DKSelectionPDFView.h
+++ b/framework/Code/DKSelectionPDFView.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawingView.h"
 

--- a/framework/Code/DKSelectionPDFView.m
+++ b/framework/Code/DKSelectionPDFView.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKSelectionPDFView.h"
 #import "DKDrawing.h"

--- a/framework/Code/DKShapeCluster.h
+++ b/framework/Code/DKShapeCluster.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKShapeGroup.h"
 

--- a/framework/Code/DKShapeCluster.m
+++ b/framework/Code/DKShapeCluster.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKShapeCluster.h"
 

--- a/framework/Code/DKShapeFactory.h
+++ b/framework/Code/DKShapeFactory.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKShapeFactory.m
+++ b/framework/Code/DKShapeFactory.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKShapeFactory.h"
 #import "DKDrawKitMacros.h"

--- a/framework/Code/DKShapeGroup.h
+++ b/framework/Code/DKShapeGroup.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape.h"
 #import "DKDrawableContainerProtocol.h"

--- a/framework/Code/DKShapeGroup.m
+++ b/framework/Code/DKShapeGroup.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKShapeGroup.h"
 #import "DKGeometryUtilities.h"

--- a/framework/Code/DKStroke.h
+++ b/framework/Code/DKStroke.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 

--- a/framework/Code/DKStroke.m
+++ b/framework/Code/DKStroke.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStroke.h"
 #import "DKStyle.h"

--- a/framework/Code/DKStrokeDash.h
+++ b/framework/Code/DKStrokeDash.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKStrokeDash.m
+++ b/framework/Code/DKStrokeDash.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStrokeDash.h"
 #import "DKDrawKitMacros.h"

--- a/framework/Code/DKStyle+SimpleAccess.h
+++ b/framework/Code/DKStyle+SimpleAccess.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStyle.h"
 

--- a/framework/Code/DKStyle+SimpleAccess.m
+++ b/framework/Code/DKStyle+SimpleAccess.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStyle+SimpleAccess.h"
 #import "DKFill.h"

--- a/framework/Code/DKStyle+Text.h
+++ b/framework/Code/DKStyle+Text.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStyle.h"
 

--- a/framework/Code/DKStyle+Text.m
+++ b/framework/Code/DKStyle+Text.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStyle+Text.h"
 #import "DKFill.h"

--- a/framework/Code/DKStyle.h
+++ b/framework/Code/DKStyle.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRastGroup.h"
 

--- a/framework/Code/DKStyle.m
+++ b/framework/Code/DKStyle.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStyle.h"
 #import "DKStyleRegistry.h"

--- a/framework/Code/DKStyleReader.h
+++ b/framework/Code/DKStyleReader.h
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKEvaluator.h"
 

--- a/framework/Code/DKStyleReader.m
+++ b/framework/Code/DKStyleReader.m
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStyleReader.h"
 

--- a/framework/Code/DKStyleRegistry.h
+++ b/framework/Code/DKStyleRegistry.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKCategoryManager.h"

--- a/framework/Code/DKStyleRegistry.m
+++ b/framework/Code/DKStyleRegistry.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStyleRegistry.h"
 

--- a/framework/Code/DKSweptAngleGradient.h
+++ b/framework/Code/DKSweptAngleGradient.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKGradient.h"
 

--- a/framework/Code/DKSweptAngleGradient.m
+++ b/framework/Code/DKSweptAngleGradient.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKSweptAngleGradient.h"
 

--- a/framework/Code/DKTargetHandle.h
+++ b/framework/Code/DKTargetHandle.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKHandle.h"

--- a/framework/Code/DKTargetHandle.m
+++ b/framework/Code/DKTargetHandle.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKTargetHandle.h"
 #import "NSBezierPath+Geometry.h"

--- a/framework/Code/DKTextAdornment.h
+++ b/framework/Code/DKTextAdornment.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKRasterizer.h"
 #import "DKCommonTypes.h"

--- a/framework/Code/DKTextAdornment.m
+++ b/framework/Code/DKTextAdornment.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKTextAdornment.h"
 #import "DKDrawableObject+Metadata.h"

--- a/framework/Code/DKTextPath.h
+++ b/framework/Code/DKTextPath.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawablePath.h"
 #import "DKCommonTypes.h"

--- a/framework/Code/DKTextPath.m
+++ b/framework/Code/DKTextPath.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKTextPath.h"
 #import "DKTextShape.h"

--- a/framework/Code/DKTextShape.h
+++ b/framework/Code/DKTextShape.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKDrawableShape.h"
 #import "DKCommonTypes.h"

--- a/framework/Code/DKTextShape.m
+++ b/framework/Code/DKTextShape.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKTextShape.h"
 #import "DKTextAdornment.h"

--- a/framework/Code/DKTextSubstitutor.h
+++ b/framework/Code/DKTextSubstitutor.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKTextSubstitutor.m
+++ b/framework/Code/DKTextSubstitutor.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKTextSubstitutor.h"
 #import "DKDrawableObject+Metadata.h"

--- a/framework/Code/DKToolController.h
+++ b/framework/Code/DKToolController.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKViewController.h"
 

--- a/framework/Code/DKToolController.m
+++ b/framework/Code/DKToolController.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKToolController.h"
 #import "DKToolRegistry.h"

--- a/framework/Code/DKToolRegistry.h
+++ b/framework/Code/DKToolRegistry.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKToolRegistry.m
+++ b/framework/Code/DKToolRegistry.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKToolRegistry.h"
 #import "DKObjectCreationTool.h"

--- a/framework/Code/DKUnarchivingHelper.h
+++ b/framework/Code/DKUnarchivingHelper.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKUnarchivingHelper.m
+++ b/framework/Code/DKUnarchivingHelper.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKUnarchivingHelper.h"
 #import "LogEvent.h"

--- a/framework/Code/DKUndoManager.h
+++ b/framework/Code/DKUndoManager.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Foundation/Foundation.h>
 #import "GCUndoManager.h"

--- a/framework/Code/DKUndoManager.m
+++ b/framework/Code/DKUndoManager.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKUndoManager.h"
 #import "LogEvent.h"

--- a/framework/Code/DKUniqueID.h
+++ b/framework/Code/DKUniqueID.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKUniqueID.m
+++ b/framework/Code/DKUniqueID.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKUniqueID.h"
 

--- a/framework/Code/DKViewController.h
+++ b/framework/Code/DKViewController.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/DKViewController.m
+++ b/framework/Code/DKViewController.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKViewController.h"
 #import "DKDrawing.h"

--- a/framework/Code/DKZigZagFill.h
+++ b/framework/Code/DKZigZagFill.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKFill.h"
 

--- a/framework/Code/DKZigZagFill.m
+++ b/framework/Code/DKZigZagFill.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKZigZagFill.h"
 

--- a/framework/Code/DKZigZagStroke.h
+++ b/framework/Code/DKZigZagStroke.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKStroke.h"
 

--- a/framework/Code/DKZigZagStroke.m
+++ b/framework/Code/DKZigZagStroke.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKZigZagStroke.h"
 

--- a/framework/Code/DKZoomTool.h
+++ b/framework/Code/DKZoomTool.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKDrawingTool.h"

--- a/framework/Code/DKZoomTool.m
+++ b/framework/Code/DKZoomTool.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKZoomTool.h"
 #import "DKLayer.h"

--- a/framework/Code/GCInfoFloater.h
+++ b/framework/Code/GCInfoFloater.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/GCInfoFloater.m
+++ b/framework/Code/GCInfoFloater.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCInfoFloater.h"
 #import "GCOneShotEffectTimer.h"

--- a/framework/Code/GCObservableObject.h
+++ b/framework/Code/GCObservableObject.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/GCObservableObject.m
+++ b/framework/Code/GCObservableObject.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCObservableObject.h"
 #import "LogEvent.h"

--- a/framework/Code/GCOneShotEffectTimer.h
+++ b/framework/Code/GCOneShotEffectTimer.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/GCOneShotEffectTimer.m
+++ b/framework/Code/GCOneShotEffectTimer.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCOneShotEffectTimer.h"
 

--- a/framework/Code/GCThreadQueue.h
+++ b/framework/Code/GCThreadQueue.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/GCThreadQueue.m
+++ b/framework/Code/GCThreadQueue.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCThreadQueue.h"
 

--- a/framework/Code/GCUndoManager.h
+++ b/framework/Code/GCUndoManager.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/GCUndoManager.m
+++ b/framework/Code/GCUndoManager.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCUndoManager.h"
 

--- a/framework/Code/GCZoomView.h
+++ b/framework/Code/GCZoomView.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/GCZoomView.m
+++ b/framework/Code/GCZoomView.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "GCZoomView.h"
 #import "DKRetriggerableTimer.h"

--- a/framework/Code/NSAffineTransform+DKAdditions.h
+++ b/framework/Code/NSAffineTransform+DKAdditions.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSAffineTransform+DKAdditions.m
+++ b/framework/Code/NSAffineTransform+DKAdditions.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSAffineTransform+DKAdditions.h"
 

--- a/framework/Code/NSAttributedString+DKAdditions.h
+++ b/framework/Code/NSAttributedString+DKAdditions.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 #import "DKCommonTypes.h"

--- a/framework/Code/NSAttributedString+DKAdditions.m
+++ b/framework/Code/NSAttributedString+DKAdditions.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSAttributedString+DKAdditions.h"
 #import "DKBezierTextContainer.h"

--- a/framework/Code/NSBezierPath+Combinatorial.h
+++ b/framework/Code/NSBezierPath+Combinatorial.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSBezierPath+Combinatorial.m
+++ b/framework/Code/NSBezierPath+Combinatorial.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSBezierPath+Combinatorial.h"
 #import "NSBezierPath-OAExtensions.h"

--- a/framework/Code/NSBezierPath+Editing.h
+++ b/framework/Code/NSBezierPath+Editing.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSBezierPath+Editing.m
+++ b/framework/Code/NSBezierPath+Editing.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSBezierPath+Editing.h"
 

--- a/framework/Code/NSBezierPath+Geometry.h
+++ b/framework/Code/NSBezierPath+Geometry.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSBezierPath+Geometry.m
+++ b/framework/Code/NSBezierPath+Geometry.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSBezierPath+Geometry.h"
 #import "DKDrawKitMacros.h"

--- a/framework/Code/NSBezierPath+Shapes.h
+++ b/framework/Code/NSBezierPath+Shapes.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSBezierPath+Shapes.m
+++ b/framework/Code/NSBezierPath+Shapes.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSBezierPath+Shapes.h"
 #import "NSBezierPath+Geometry.h"

--- a/framework/Code/NSBezierPath+Text.h
+++ b/framework/Code/NSBezierPath+Text.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSBezierPath+Text.m
+++ b/framework/Code/NSBezierPath+Text.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSBezierPath+Text.h"
 #import "NSBezierPath+Geometry.h"

--- a/framework/Code/NSColor+DKAdditions.h
+++ b/framework/Code/NSColor+DKAdditions.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSColor+DKAdditions.m
+++ b/framework/Code/NSColor+DKAdditions.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSColor+DKAdditions.h"
 

--- a/framework/Code/NSDictionary+DeepCopy.h
+++ b/framework/Code/NSDictionary+DeepCopy.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSDictionary+DeepCopy.m
+++ b/framework/Code/NSDictionary+DeepCopy.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSDictionary+DeepCopy.h"
 

--- a/framework/Code/NSImage+DKAdditions.h
+++ b/framework/Code/NSImage+DKAdditions.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSImage+DKAdditions.m
+++ b/framework/Code/NSImage+DKAdditions.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSImage+DKAdditions.h"
 #import "DKGeometryUtilities.h"

--- a/framework/Code/NSMutableArray+DKAdditions.h
+++ b/framework/Code/NSMutableArray+DKAdditions.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSMutableArray+DKAdditions.m
+++ b/framework/Code/NSMutableArray+DKAdditions.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSMutableArray+DKAdditions.h"
 

--- a/framework/Code/NSObject+GraphicsAttributes.h
+++ b/framework/Code/NSObject+GraphicsAttributes.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSObject+GraphicsAttributes.m
+++ b/framework/Code/NSObject+GraphicsAttributes.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSObject+GraphicsAttributes.h"
 

--- a/framework/Code/NSObject+StringValue.h
+++ b/framework/Code/NSObject+StringValue.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSObject+StringValue.m
+++ b/framework/Code/NSObject+StringValue.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSObject+StringValue.h"
 #import "NSColor+DKAdditions.h"

--- a/framework/Code/NSShadow+Scaling.h
+++ b/framework/Code/NSShadow+Scaling.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSShadow+Scaling.m
+++ b/framework/Code/NSShadow+Scaling.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSShadow+Scaling.h"
 #import "NSColor+DKAdditions.h"

--- a/framework/Code/NSString+DKAdditions.h
+++ b/framework/Code/NSString+DKAdditions.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/NSString+DKAdditions.m
+++ b/framework/Code/NSString+DKAdditions.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "NSString+DKAdditions.h"
 

--- a/framework/Code/TestBSPStorage.h
+++ b/framework/Code/TestBSPStorage.h
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <SenTestingKit/SenTestingKit.h>
 #import "DKBSPDirectObjectStorage.h"

--- a/framework/Code/TestBSPStorage.m
+++ b/framework/Code/TestBSPStorage.m
@@ -1,10 +1,8 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "TestBSPStorage.h"
 #include <tgmath.h>

--- a/framework/Code/parser/DKEvaluator.h
+++ b/framework/Code/parser/DKEvaluator.h
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/parser/DKEvaluator.m
+++ b/framework/Code/parser/DKEvaluator.m
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKEvaluator.h"
 

--- a/framework/Code/parser/DKExpression.h
+++ b/framework/Code/parser/DKExpression.h
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Foundation/Foundation.h>
 

--- a/framework/Code/parser/DKExpression.m
+++ b/framework/Code/parser/DKExpression.m
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKExpression.h"
 

--- a/framework/Code/parser/DKParser.h
+++ b/framework/Code/parser/DKParser.h
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Foundation/Foundation.h>
 

--- a/framework/Code/parser/DKParser.m
+++ b/framework/Code/parser/DKParser.m
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKParser.h"
 

--- a/framework/Code/parser/DKScriptingAdditions.h
+++ b/framework/Code/parser/DKScriptingAdditions.h
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/parser/DKScriptingAdditions.m
+++ b/framework/Code/parser/DKScriptingAdditions.m
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKScriptingAdditions.h"
 

--- a/framework/Code/parser/DKSymbol.h
+++ b/framework/Code/parser/DKSymbol.h
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import <Cocoa/Cocoa.h>
 

--- a/framework/Code/parser/DKSymbol.m
+++ b/framework/Code/parser/DKSymbol.m
@@ -1,11 +1,9 @@
 /**
- @author Graham Cox, Apptree.net
- @author Graham Miln, miln.eu
  @author Jason Jobe
- @author Contributions from the community
- @date 2005-2014
- @copyright This software is released subject to licensing conditions as detailed in DRAWKIT-LICENSING.TXT, which must accompany this source file.
- */
+ @author Contributions from the community; see CONTRIBUTORS.md
+ @date 2005-2015
+ @copyright GNU GPL3; see LICENSE
+*/
 
 #import "DKSymbol.h"
 


### PR DESCRIPTION
Ensuring contributions through third party code is acknowledged in `CONTRIBUTORS.md`.
Updating copyright block with `LICENSE` reference, year, and authors.