### PR TITLE
Adding `infoLengthForPath:` to support customised lengths

### DIFF
--- a/framework/Code/DKDrawablePath.h
+++ b/framework/Code/DKDrawablePath.h
@@ -148,6 +148,14 @@ maintain the concept of rotation or scale - it just is what it is.
 - (CGFloat)lengthForPoint:(NSPoint)mp;
 - (CGFloat)lengthForPoint:(NSPoint)mp tolerance:(CGFloat)tol;
 
+/** @brief Return the length to display to the user of a path
+ 
+ By default returns the same value as length. Override where the last path segment
+ length should be shown instead of the total path length.
+ @return the path's display length in points
+ */
+- (CGFloat)infoLengthForPath:(NSBezierPath*)path;
+
 /** @brief Discover whether the path is open or closed
 
  A path is closed if it has a closePath element or its first and last points are coincident.

--- a/framework/Code/DKDrawablePath.m
+++ b/framework/Code/DKDrawablePath.m
@@ -412,6 +412,12 @@ static NSColor* sInfoWindowColour = nil;
 											 tolerance:tol];
 }
 
+- (CGFloat)infoLengthForPath:(NSBezierPath*)path
+{
+	NSParameterAssert(path);
+	return [path length];
+}
+
 - (void)recordPathForUndo
 {
 	[m_undoPath release];
@@ -874,7 +880,7 @@ static NSColor* sInfoWindowColour = nil;
 						  forPartcode:partcodeForElementControlPoint(element - 1, 1)];
 			}
 
-			[self showLengthInfo:[path length]
+			[self showLengthInfo:[self infoLengthForPath:path]
 						 atPoint:nsp];
 			break;
 
@@ -889,7 +895,7 @@ static NSColor* sInfoWindowColour = nil;
 					  forPartcode:partcode];
 			[path setControlPoint:p
 					  forPartcode:partcodeForElementControlPoint(element, 1)];
-			[self showLengthInfo:[path length]
+			[self showLengthInfo:[self infoLengthForPath:path]
 						 atPoint:nsp];
 			break;
 
@@ -985,7 +991,7 @@ finish:
 			[view autoscroll:theEvent];
 			[path setControlPoint:p
 					  forPartcode:partcode];
-			[self showLengthInfo:[path length]
+			[self showLengthInfo:[self infoLengthForPath:path]
 						 atPoint:nsp];
 			break;
 
@@ -1003,7 +1009,7 @@ finish:
 			[view autoscroll:theEvent];
 			[path setControlPoint:p
 					  forPartcode:partcode];
-			[self showLengthInfo:[path length]
+			[self showLengthInfo:[self infoLengthForPath:path]
 						 atPoint:nsp];
 			break;
 
@@ -1157,7 +1163,7 @@ finish:
 			[self notifyVisualChange];
 			[path setControlPoint:p
 					  forPartcode:partcode];
-			[self showLengthInfo:[path length]
+			[self showLengthInfo:[self infoLengthForPath:path]
 						 atPoint:nsp];
 			break;
 


### PR DESCRIPTION
`DKDrawablePath` uses a private method to display path lengths during creation. This length was fixed at the total length of the path. I have a need for only the last path segment's length to be displayed.

Added `infoLengthForPath:` to provide an method for subclasses to override. The default behaviour remains unchanged.