### PR TITLE
Fixed numerous warnings

### DIFF
--- a/framework/Code/DKArcPath.h
+++ b/framework/Code/DKArcPath.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawablePath.h"

--- a/framework/Code/DKArcPath.m
+++ b/framework/Code/DKArcPath.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKArcPath.h"
@@ -370,7 +370,6 @@ static CGFloat sAngleConstraint = 0.261799387799; // 15°
 					if (angle < 0)
 						angle += 360.0f;
 
-#warning 64BIT: Check formatting arguments
 					[[self layer] showInfoWindowWithString:[NSString stringWithFormat:@"radius: %.2f%@\nangle: %.1f%C", rad, abbrUnits, angle, 0xB0]
 												   atPoint:nsp];
 				}
@@ -385,7 +384,6 @@ static CGFloat sAngleConstraint = 0.261799387799; // 15°
 					if (angle < 0)
 						angle = 360.0 + angle;
 
-#warning 64BIT: Check formatting arguments
 					[[self layer] showInfoWindowWithString:[NSString stringWithFormat:@"radius: %.2f%@\narc angle: %.1f%C", rad, abbrUnits, angle, 0xB0]
 												   atPoint:nsp];
 				}
@@ -589,13 +587,11 @@ static CGFloat sAngleConstraint = 0.261799387799; // 15°
 		case kDKDrawingEntireObjectPart:
 		case kDKArcPathCentrePointPart:
 			gridPt = [self convertPointToDrawing:[self location]];
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"centre x: %.2f%@\ncentre y: %.2f%@", gridPt.x, abbrUnits, gridPt.y, abbrUnits];
 			break;
 
 		case kDKArcPathRotationKnobPart:
 			angle = [self angleInDegrees];
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"radius: %.2f%@\nangle: %.1f%C", rad, abbrUnits, angle, 0xB0];
 			break;
 
@@ -603,7 +599,6 @@ static CGFloat sAngleConstraint = 0.261799387799; // 15°
 			angle = RADIANS_TO_DEGREES(mEndAngle - mStartAngle);
 			if (angle < 0)
 				angle += 360.0f;
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"radius: %.2f%@\narc angle: %.1f%C", rad, abbrUnits, angle, 0xB0];
 			break;
 		}

--- a/framework/Code/DKArrowStroke.h
+++ b/framework/Code/DKArrowStroke.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStroke.h"

--- a/framework/Code/DKArrowStroke.m
+++ b/framework/Code/DKArrowStroke.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKArrowStroke.h"
@@ -632,7 +632,6 @@ NSString* kDKDimensionUnitsKey = @"DKDimensionUnits";
 			dimText = [[self formatter] attributedStringForObjectValue:[NSNumber numberWithDouble:lengthOfPath]
 												 withDefaultAttributes:[[self class] dimensioningLineTextAttributes]];
 		} else {
-#warning 64BIT: Check formatting arguments
 			dimstr = [NSString stringWithFormat:@"%.2f", lengthOfPath];
 			dimText = [[NSAttributedString alloc] initWithString:dimstr
 													  attributes:[[self class] dimensioningLineTextAttributes]];
@@ -675,10 +674,8 @@ NSString* kDKDimensionUnitsKey = @"DKDimensionUnits";
 		}
 
 		if (plusTol == minusTol)
-#warning 64BIT: Check formatting arguments
 			return [NSString stringWithFormat:@" ±%.2f", plusTol];
 		else
-#warning 64BIT: Check formatting arguments
 			return [NSString stringWithFormat:@" +%.2f, -%.2f", plusTol, minusTol];
 	}
 }

--- a/framework/Code/DKAuxiliaryMenus.h
+++ b/framework/Code/DKAuxiliaryMenus.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKAuxiliaryMenus.m
+++ b/framework/Code/DKAuxiliaryMenus.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKAuxiliaryMenus.h"

--- a/framework/Code/DKBSPDirectObjectStorage.h
+++ b/framework/Code/DKBSPDirectObjectStorage.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKBSPDirectObjectStorage.m
+++ b/framework/Code/DKBSPDirectObjectStorage.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKBSPDirectObjectStorage.h"
@@ -17,10 +17,10 @@ static inline NSUInteger depthForObjectCount(NSUInteger n)
 	return (n > 0 ? MAX((NSUInteger)_CGFloatCeil(_CGFloatLog((CGFloat)n)) / _CGFloatLog(2.0f), kDKMinimumDepth) : 0);
 }
 
-static inline NSUInteger childNodeAtIndex(NSUInteger nodeIndex)
-{
-	return (nodeIndex << 1) + 1;
-}
+//static inline NSUInteger childNodeAtIndex(NSUInteger nodeIndex)
+//{
+//	return (nodeIndex << 1) + 1;
+//}
 
 @interface DKBSPDirectObjectStorage (Private)
 
@@ -667,7 +667,6 @@ static void addValueToFoundObjects(const void* value, void* context)
 
 - (NSString*)description
 {
-#warning 64BIT: Inspect use of long
 	return [NSString stringWithFormat:@"<%@ %p>, %ld leaves = %@", NSStringFromClass([self class]), self, (long)[self countOfLeaves], mLeaves];
 }
 

--- a/framework/Code/DKBSPObjectStorage.h
+++ b/framework/Code/DKBSPObjectStorage.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKBSPObjectStorage.m
+++ b/framework/Code/DKBSPObjectStorage.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKBSPObjectStorage.h"
@@ -783,8 +783,6 @@ static NSUInteger sLeafCount = 0;
 - (NSString*)description
 {
 // warning: description string can be very large, as it enumerates the leaves
-
-#warning 64BIT: Inspect use of long
 	return [NSString stringWithFormat:@"<%@ %p>, %ld leaves = %@", NSStringFromClass([self class]), self, (long)[self countOfLeaves], mLeaves];
 }
 

--- a/framework/Code/DKBezierLayoutManager.h
+++ b/framework/Code/DKBezierLayoutManager.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKBezierLayoutManager.m
+++ b/framework/Code/DKBezierLayoutManager.m
@@ -39,46 +39,46 @@
 		while (glyphIndex < glyphRange.length) {
 			// look at the formatting applied to individual glyphs so that the path applies that formatting as necessary.
 
-			NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+			@autoreleasepool {
 
-			NSUInteger g;
-			NSPoint gloc, ploc;
-			NSFont* font;
+				NSUInteger g;
+				NSPoint gloc, ploc;
+				NSFont* font;
 
-			fragRect = [self lineFragmentRectForGlyphAtIndex:glyphIndex
-											  effectiveRange:&grange];
+				fragRect = [self lineFragmentRectForGlyphAtIndex:glyphIndex
+												  effectiveRange:&grange];
 
-			for (g = grange.location; g < grange.location + grange.length; ++g) {
-				temp = [NSBezierPath bezierPath];
-				ploc = gloc = [self locationForGlyphAtIndex:g];
+				for (g = grange.location; g < grange.location + grange.length; ++g) {
+					temp = [NSBezierPath bezierPath];
+					ploc = gloc = [self locationForGlyphAtIndex:g];
 
-				ploc.x -= fragRect.origin.x;
-				ploc.y = fragRect.origin.y;
+					ploc.x -= fragRect.origin.x;
+					ploc.y = fragRect.origin.y;
 
-				font = [[[self textStorage] attributesAtIndex:g
-											   effectiveRange:NULL] objectForKey:NSFontAttributeName];
+					font = [[[self textStorage] attributesAtIndex:g
+												   effectiveRange:NULL] objectForKey:NSFontAttributeName];
 
-				[temp moveToPoint:ploc];
-				[temp appendBezierPathWithGlyph:[self glyphAtIndex:g]
-										 inFont:font];
+					[temp moveToPoint:ploc];
+					[temp appendBezierPathWithGlyph:[self glyphAtIndex:g]
+											 inFont:font];
 
-				// need to vertically flip and offset each glyph as it is created. The glyph is flipped around its given location to
-				// ensure that any unusual baseline requirements are taken into consideration.
+					// need to vertically flip and offset each glyph as it is created. The glyph is flipped around its given location to
+					// ensure that any unusual baseline requirements are taken into consideration.
 
-				NSAffineTransform* xform = [NSAffineTransform transform];
-				[xform translateXBy:ploc.x
-								yBy:ploc.y];
-				[xform scaleXBy:1.0
-							yBy:-1.0];
-				[xform translateXBy:-ploc.x
-								yBy:-ploc.y];
-				[temp transformUsingAffineTransform:xform];
+					NSAffineTransform* xform = [NSAffineTransform transform];
+					[xform translateXBy:ploc.x
+									yBy:ploc.y];
+					[xform scaleXBy:1.0
+								yBy:-1.0];
+					[xform translateXBy:-ploc.x
+									yBy:-ploc.y];
+					[temp transformUsingAffineTransform:xform];
 
-				[array addObject:temp];
+					[array addObject:temp];
+				}
+				// next line:
+				glyphIndex += grange.length;
 			}
-			// next line:
-			glyphIndex += grange.length;
-			[pool drain];
 		}
 	}
 

--- a/framework/Code/DKBezierTextContainer.h
+++ b/framework/Code/DKBezierTextContainer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKBezierTextContainer.m
+++ b/framework/Code/DKBezierTextContainer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKBezierTextContainer.h"

--- a/framework/Code/DKBoundingRectHandle.h
+++ b/framework/Code/DKBoundingRectHandle.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKBoundingRectHandle.m
+++ b/framework/Code/DKBoundingRectHandle.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKBoundingRectHandle.h"

--- a/framework/Code/DKCIFilterRastGroup.h
+++ b/framework/Code/DKCIFilterRastGroup.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRastGroup.h"

--- a/framework/Code/DKCategoryManager.h
+++ b/framework/Code/DKCategoryManager.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKCategoryManager.m
+++ b/framework/Code/DKCategoryManager.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKCategoryManager.h"

--- a/framework/Code/DKColourQuantizer.h
+++ b/framework/Code/DKColourQuantizer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKColourQuantizer.m
+++ b/framework/Code/DKColourQuantizer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKColourQuantizer.h"
@@ -224,7 +224,6 @@ static NSUInteger mask[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
 
 - (NODE*)createNodeAtLevel:(NSUInteger)level leafCount:(NSUInteger*)leafCount reducibleNodes:(NODE**)redNodes
 {
-#warning 64BIT: Inspect use of sizeof
 	NODE* pnode = (NODE*)calloc(1, sizeof(NODE));
 
 	if (pnode == NULL)
@@ -380,7 +379,6 @@ static NSUInteger mask[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
 		NSUInteger i, indx = 0;
 		NSColor* colour;
 
-#warning 64BIT: Inspect use of sizeof
 		rgb = (rgb_triple*)malloc(m_nLeafCount * sizeof(rgb_triple));
 		[self paletteColour:m_pTree
 					  index:&indx

--- a/framework/Code/DKCommonTypes.h
+++ b/framework/Code/DKCommonTypes.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 // functional types, as passed to drawKnobAtPoint:ofType:userInfo:

--- a/framework/Code/DKCropTool.h
+++ b/framework/Code/DKCropTool.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingTool.h"

--- a/framework/Code/DKCropTool.m
+++ b/framework/Code/DKCropTool.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKCropTool.h"
@@ -66,10 +66,6 @@
 
 	mZoomRect = NSRectFromTwoPoints(mAnchor, p);
 	[layer setNeedsDisplayInRect:mZoomRect];
-
-	DKObjectDrawingLayer* odl = (DKObjectDrawingLayer*)layer;
-
-	[odl cropToRect:mZoomRect];
 
 	mZoomRect = NSZeroRect;
 	return NO;

--- a/framework/Code/DKDistortionTransform.h
+++ b/framework/Code/DKDistortionTransform.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDistortionTransform.mm
+++ b/framework/Code/DKDistortionTransform.mm
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDistortionTransform.h"
@@ -39,8 +39,6 @@ static NSPoint Map(NSPoint inPoint, NSSize sourceSize, NSPoint quad[4])
 
 	NSPoint p;
 
-#warning 64BIT: Inspect pointer casting
-#warning 64BIT: Inspect pointer casting
 	VP((CGFloat*)&p.x, (CGFloat*)&p.y,
 	   (CGFloat)((sourceSize.height - inPoint.y) * quad[0].x + (inPoint.y) * quad[3].x) / sourceSize.height, (CGFloat)((sourceSize.height - inPoint.y) * quad[0].y + inPoint.y * quad[3].y) / sourceSize.height,
 	   (CGFloat)((sourceSize.height - inPoint.y) * quad[1].x + (inPoint.y) * quad[2].x) / sourceSize.height, (CGFloat)((sourceSize.height - inPoint.y) * quad[1].y + inPoint.y * quad[2].y) / sourceSize.height,

--- a/framework/Code/DKDrawKit.h
+++ b/framework/Code/DKDrawKit.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE @licence LGPL3
+ @copyright GNU LGPL3; see LICENSE @licence LGPL3
  */
 
 #import "DKDrawingView.h"

--- a/framework/Code/DKDrawKitMacros.h
+++ b/framework/Code/DKDrawKitMacros.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 //#import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawKit_Prefix.pch
+++ b/framework/Code/DKDrawKit_Prefix.pch
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE Prefix header for all source files of the 'DrawKit' target in the 'DrawKit' project. */
+ @copyright GNU LGPL3; see LICENSE Prefix header for all source files of the 'DrawKit' target in the 'DrawKit' project. */
 
 #ifndef qDebug
 #define NS_BLOCK_ASSERTIONS

--- a/framework/Code/DKDrawableContainerProtocol.h
+++ b/framework/Code/DKDrawableContainerProtocol.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawableObject+Metadata.h
+++ b/framework/Code/DKDrawableObject+Metadata.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableObject.h"

--- a/framework/Code/DKDrawableObject+Metadata.m
+++ b/framework/Code/DKDrawableObject+Metadata.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableObject+Metadata.h"
@@ -233,12 +233,10 @@ NSString* kDKUndoableChangesUserDefaultsKey = @"DKMetadataChangesAreNotUndoable"
 					const char* dataType = [oldValue objCType];
 					NSNumber* newValue;
 
-#warning 64BIT: Inspect use of @encode
 					if (strcmp(dataType, @encode(CGFloat)) == 0)
 						newValue = [NSNumber numberWithDouble:[obj doubleValue]];
 					else if (strcmp(dataType, @encode(double)) == 0)
 						newValue = [NSNumber numberWithDouble:[obj doubleValue]];
-#warning 64BIT: Inspect use of @encode
 					else if (strcmp(dataType, @encode(NSInteger)) == 0)
 						newValue = [NSNumber numberWithInteger:[obj integerValue]];
 					else if (strcmp(dataType, @encode(BOOL)) == 0)

--- a/framework/Code/DKDrawableObject.h
+++ b/framework/Code/DKDrawableObject.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawableObject.m
+++ b/framework/Code/DKDrawableObject.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableObject.h"
@@ -729,52 +729,52 @@ static NSDictionary* s_interconversionTable = nil;
  */
 - (void)drawContentWithSelectedState:(BOOL)selected
 {
-	NSAutoreleasePool* pool = [NSAutoreleasePool new];
+	@autoreleasepool {
 
 #ifdef qIncludeGraphicDebugging
-	[NSGraphicsContext saveGraphicsState];
+		[NSGraphicsContext saveGraphicsState];
 
-	if (m_clipToBBox) {
-		NSBezierPath* clipPath = [NSBezierPath bezierPathWithRect:[self bounds]];
-		[clipPath addClip];
-	}
+		if (m_clipToBBox) {
+			NSBezierPath* clipPath = [NSBezierPath bezierPathWithRect:[self bounds]];
+			[clipPath addClip];
+		}
 #endif
-	// draw the object's actual content
+		// draw the object's actual content
 
-	mIsHitTesting = NO;
-	[self drawContent];
+		mIsHitTesting = NO;
+		[self drawContent];
 
-	// draw the selection highlight - other code should have already checked -objectMayBecomeSelected and refused to
-	// select the object but if for some reason this wasn't done, this at least supresses the highlight
+		// draw the selection highlight - other code should have already checked -objectMayBecomeSelected and refused to
+		// select the object but if for some reason this wasn't done, this at least supresses the highlight
 
-	if (selected && [self objectMayBecomeSelected])
-		[self drawSelectedState];
+		if (selected && [self objectMayBecomeSelected])
+			[self drawSelectedState];
 
 #ifdef qIncludeGraphicDebugging
 
-	[NSGraphicsContext restoreGraphicsState];
+		[NSGraphicsContext restoreGraphicsState];
 
-	if (m_showBBox) {
-		CGFloat sc = 0.5f / [(DKDrawingView*)[self currentView] scale];
+		if (m_showBBox) {
+			CGFloat sc = 0.5f / [(DKDrawingView*)[self currentView] scale];
 
-		[[NSColor redColor] set];
+			[[NSColor redColor] set];
 
-		NSRect bb = [self bounds];
-		bb = NSInsetRect(bb, sc, sc);
-		NSBezierPath* bbox = [NSBezierPath bezierPathWithRect:bb];
+			NSRect bb = [self bounds];
+			bb = NSInsetRect(bb, sc, sc);
+			NSBezierPath* bbox = [NSBezierPath bezierPathWithRect:bb];
 
-		[bbox moveToPoint:bb.origin];
-		[bbox lineToPoint:NSMakePoint(NSMaxX(bb), NSMaxY(bb))];
-		[bbox moveToPoint:NSMakePoint(NSMaxX(bb), NSMinY(bb))];
-		[bbox lineToPoint:NSMakePoint(NSMinX(bb), NSMaxY(bb))];
+			[bbox moveToPoint:bb.origin];
+			[bbox lineToPoint:NSMakePoint(NSMaxX(bb), NSMaxY(bb))];
+			[bbox moveToPoint:NSMakePoint(NSMaxX(bb), NSMinY(bb))];
+			[bbox lineToPoint:NSMakePoint(NSMinX(bb), NSMaxY(bb))];
 
-		[bbox setLineWidth:0.0];
-		[bbox stroke];
-	}
+			[bbox setLineWidth:0.0];
+			[bbox stroke];
+		}
 
 #endif
 
-	[pool drain];
+	}
 }
 
 - (void)drawContent
@@ -2320,8 +2320,7 @@ static NSRect s_oldBounds;
 
 - (NSString*)description
 {
-#warning 64BIT: Check formatting arguments
-	return [NSString stringWithFormat:@"%@ size: %@, loc: %@, angle: %.4f, offset: %@, locked: %@, style: %@, container: %x, storage: %@, user info:%@",
+	return [NSString stringWithFormat:@"%@ size: %@, loc: %@, angle: %.4f, offset: %@, locked: %@, style: %@, container: %p, storage: %@, user info:%@",
 									  [super description],
 									  NSStringFromSize([self size]),
 									  NSStringFromPoint([self location]),
@@ -2443,7 +2442,6 @@ static NSRect s_oldBounds;
 				NSString* name = [theStyle name];
 
 				if (name && [name length] > 0)
-#warning 64BIT: Check formatting arguments
 					itemTitle = [NSString stringWithFormat:NSLocalizedString(@"Paste Style '%@'", nil), name];
 
 				// don't bother pasting the same style we already have
@@ -2465,7 +2463,6 @@ static NSRect s_oldBounds;
 		if (theStyle) {
 			NSString* name = [theStyle name];
 			if (name && [name length] > 0)
-#warning 64BIT: Check formatting arguments
 				itemTitle = [NSString stringWithFormat:NSLocalizedString(@"Copy Style '%@'", nil), name];
 		}
 		[item setTitle:itemTitle];

--- a/framework/Code/DKDrawablePath.h
+++ b/framework/Code/DKDrawablePath.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableObject.h"

--- a/framework/Code/DKDrawableShape+Hotspots.h
+++ b/framework/Code/DKDrawableShape+Hotspots.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape.h"

--- a/framework/Code/DKDrawableShape+Hotspots.m
+++ b/framework/Code/DKDrawableShape+Hotspots.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape+Hotspots.h"

--- a/framework/Code/DKDrawableShape+Utilities.h
+++ b/framework/Code/DKDrawableShape+Utilities.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawableShape+Utilities.m
+++ b/framework/Code/DKDrawableShape+Utilities.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape+Utilities.h"

--- a/framework/Code/DKDrawableShape.h
+++ b/framework/Code/DKDrawableShape.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableObject.h"

--- a/framework/Code/DKDrawableShape.m
+++ b/framework/Code/DKDrawableShape.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape.h"
@@ -1454,7 +1454,6 @@ static NSSize sTempSavedOffset;
 			break;
 
 		case kDKShapeOperationRotate:
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"%.1f%C", [self angleInDegrees], 0xB0]; // UTF-8 for degree symbol is 0xB0
 			break;
 		}
@@ -1912,56 +1911,56 @@ static NSSize sTempSavedOffset;
  */
 - (void)drawSelectedState
 {
-	NSAutoreleasePool* pool = [NSAutoreleasePool new];
+	@autoreleasepool {
 
-	if (m_inRotateOp) {
-		[[[self layer] knobs] drawRotationBarWithKnobsFromCentre:[self knobPoint:kDKDrawableShapeOriginTarget]
-														 toPoint:sTempRotationPt];
+		if (m_inRotateOp) {
+			[[[self layer] knobs] drawRotationBarWithKnobsFromCentre:[self knobPoint:kDKDrawableShapeOriginTarget]
+															 toPoint:sTempRotationPt];
 
-	} else {
-		if ([self operationMode] != kDKShapeTransformStandard)
-			[self drawDistortionEnvelope];
-		else {
-			// draw the bounding box:
+		} else {
+			if ([self operationMode] != kDKShapeTransformStandard)
+				[self drawDistortionEnvelope];
+			else {
+				// draw the bounding box:
 
-			NSBezierPath* pp = [NSBezierPath bezierPathWithRect:[[self class] unitRectAtOrigin]];
+				NSBezierPath* pp = [NSBezierPath bezierPathWithRect:[[self class] unitRectAtOrigin]];
 
-			if ([self distortionTransform] != nil)
-				pp = [[self distortionTransform] transformBezierPath:pp];
+				if ([self distortionTransform] != nil)
+					pp = [[self distortionTransform] transformBezierPath:pp];
 
-			[pp transformUsingAffineTransform:[self transformIncludingParent]];
-			[self drawSelectionPath:pp];
+				[pp transformUsingAffineTransform:[self transformIncludingParent]];
+				[self drawSelectionPath:pp];
 
-			// draw the knobs:
-			// n.b. drawKnob is a no-op for knobs not included by +knobMask
+				// draw the knobs:
+				// n.b. drawKnob is a no-op for knobs not included by +knobMask
 
-			[self drawKnob:kDKDrawableShapeLeftHandle];
-			[self drawKnob:kDKDrawableShapeTopHandle];
-			[self drawKnob:kDKDrawableShapeRightHandle];
-			[self drawKnob:kDKDrawableShapeBottomHandle];
-			[self drawKnob:kDKDrawableShapeTopLeftHandle];
-			[self drawKnob:kDKDrawableShapeTopRightHandle];
-			[self drawKnob:kDKDrawableShapeBottomLeftHandle];
-			[self drawKnob:kDKDrawableShapeBottomRightHandle];
+				[self drawKnob:kDKDrawableShapeLeftHandle];
+				[self drawKnob:kDKDrawableShapeTopHandle];
+				[self drawKnob:kDKDrawableShapeRightHandle];
+				[self drawKnob:kDKDrawableShapeBottomHandle];
+				[self drawKnob:kDKDrawableShapeTopLeftHandle];
+				[self drawKnob:kDKDrawableShapeTopRightHandle];
+				[self drawKnob:kDKDrawableShapeBottomLeftHandle];
+				[self drawKnob:kDKDrawableShapeBottomRightHandle];
 
-			// the other knobs and any hotspots are not drawn when in a locked state
+				// the other knobs and any hotspots are not drawn when in a locked state
 
-			if (![self locked]) {
-				[self drawKnob:kDKDrawableShapeRotationHandle];
+				if (![self locked]) {
+					[self drawKnob:kDKDrawableShapeRotationHandle];
 
-				// draw the shape's origin target
+					// draw the shape's origin target
 
-				if (!m_hideOriginTarget)
-					[self drawKnob:kDKDrawableShapeOriginTarget];
+					if (!m_hideOriginTarget)
+						[self drawKnob:kDKDrawableShapeOriginTarget];
 
-				// draw the hotspots
+					// draw the hotspots
 
-				[self drawHotspotsInState:kDKHotspotStateOn];
+					[self drawHotspotsInState:kDKHotspotStateOn];
+				}
 			}
 		}
-	}
 
-	[pool drain];
+	}
 }
 
 /** @brief Hit test the point against the object

--- a/framework/Code/DKDrawing+Export.h
+++ b/framework/Code/DKDrawing+Export.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawing.h"

--- a/framework/Code/DKDrawing+Export.m
+++ b/framework/Code/DKDrawing+Export.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawing+Export.h"

--- a/framework/Code/DKDrawing+Paper.h
+++ b/framework/Code/DKDrawing+Paper.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawing+Paper.m
+++ b/framework/Code/DKDrawing+Paper.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawing+Paper.h"

--- a/framework/Code/DKDrawing.h
+++ b/framework/Code/DKDrawing.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayerGroup.h"

--- a/framework/Code/DKDrawing.m
+++ b/framework/Code/DKDrawing.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawing.h"

--- a/framework/Code/DKDrawingDocument.h
+++ b/framework/Code/DKDrawingDocument.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawingDocument.m
+++ b/framework/Code/DKDrawingDocument.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingDocument.h"

--- a/framework/Code/DKDrawingInfoLayer.h
+++ b/framework/Code/DKDrawingInfoLayer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKDrawingInfoLayer.m
+++ b/framework/Code/DKDrawingInfoLayer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingInfoLayer.h"

--- a/framework/Code/DKDrawingTool.h
+++ b/framework/Code/DKDrawingTool.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingToolProtocol.h"

--- a/framework/Code/DKDrawingTool.m
+++ b/framework/Code/DKDrawingTool.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectCreationTool.h"

--- a/framework/Code/DKDrawingToolProtocol.h
+++ b/framework/Code/DKDrawingToolProtocol.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawingView+Drop.h
+++ b/framework/Code/DKDrawingView+Drop.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingView.h"

--- a/framework/Code/DKDrawingView+Drop.m
+++ b/framework/Code/DKDrawingView+Drop.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingView+Drop.h"

--- a/framework/Code/DKDrawingView.h
+++ b/framework/Code/DKDrawingView.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCZoomView.h"

--- a/framework/Code/DKDrawingView.m
+++ b/framework/Code/DKDrawingView.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingView.h"

--- a/framework/Code/DKDrawkitInspectorBase.h
+++ b/framework/Code/DKDrawkitInspectorBase.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKDrawkitInspectorBase.m
+++ b/framework/Code/DKDrawkitInspectorBase.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawkitInspectorBase.h"
@@ -79,8 +79,7 @@
 {
 #pragma unused(subsel, object)
 
-#warning 64BIT: Check formatting arguments
-	NSLog(@"subselection of <%@ 0x%x> changed: %@", NSStringFromClass([object class]), object, subsel);
+	NSLog(@"subselection of <%@ 0x%p> changed: %@", NSStringFromClass([object class]), object, subsel);
 
 	// override to do something useful
 }

--- a/framework/Code/DKFill.h
+++ b/framework/Code/DKFill.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKFill.m
+++ b/framework/Code/DKFill.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKFill.h"

--- a/framework/Code/DKFillPattern.h
+++ b/framework/Code/DKFillPattern.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKPathDecorator.h"

--- a/framework/Code/DKGeometryUtilities.h
+++ b/framework/Code/DKGeometryUtilities.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKGeometryUtilities.m
+++ b/framework/Code/DKGeometryUtilities.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGeometryUtilities.h"

--- a/framework/Code/DKGradient+UISupport.h
+++ b/framework/Code/DKGradient+UISupport.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKGradient+UISupport.m
+++ b/framework/Code/DKGradient+UISupport.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGradient+UISupport.h"

--- a/framework/Code/DKGradient.h
+++ b/framework/Code/DKGradient.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCObservableObject.h"

--- a/framework/Code/DKGradient.m
+++ b/framework/Code/DKGradient.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGradient.h"

--- a/framework/Code/DKGradientExtensions.h
+++ b/framework/Code/DKGradientExtensions.h
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGradient.h"

--- a/framework/Code/DKGradientExtensions.m
+++ b/framework/Code/DKGradientExtensions.m
@@ -2,7 +2,7 @@
  @author Jason Job
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGradientExtensions.h"

--- a/framework/Code/DKGreekingLayoutManager.h
+++ b/framework/Code/DKGreekingLayoutManager.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKGreekingLayoutManager.m
+++ b/framework/Code/DKGreekingLayoutManager.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGreekingLayoutManager.h"

--- a/framework/Code/DKGridLayer.h
+++ b/framework/Code/DKGridLayer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKGridLayer.m
+++ b/framework/Code/DKGridLayer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGridLayer.h"

--- a/framework/Code/DKGuideLayer.h
+++ b/framework/Code/DKGuideLayer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKGuideLayer.m
+++ b/framework/Code/DKGuideLayer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGuideLayer.h"
@@ -860,11 +860,9 @@ static BOOL sWasInside = NO;
 			NSPoint gp = [[[self drawing] gridLayer] gridLocationForPoint:gg];
 
 			if ([m_dragGuideRef isVerticalGuide])
-#warning 64BIT: Check formatting arguments
 				[self showInfoWindowWithString:[NSString stringWithFormat:@"%.2f", gp.x]
 									   atPoint:p];
 			else
-#warning 64BIT: Check formatting arguments
 				[self showInfoWindowWithString:[NSString stringWithFormat:@"%.2f", gp.y]
 									   atPoint:p];
 		}
@@ -912,12 +910,10 @@ static BOOL sWasInside = NO;
 
 		if ([m_dragGuideRef isVerticalGuide]) {
 			if ([self showsDragInfoWindow])
-#warning 64BIT: Check formatting arguments
 				[self showInfoWindowWithString:[NSString stringWithFormat:@"%.2f", gp.x]
 									   atPoint:p];
 		} else {
 			if ([self showsDragInfoWindow])
-#warning 64BIT: Check formatting arguments
 				[self showInfoWindowWithString:[NSString stringWithFormat:@"%.2f", gp.y]
 									   atPoint:p];
 		}

--- a/framework/Code/DKHandle.h
+++ b/framework/Code/DKHandle.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKHandle.m
+++ b/framework/Code/DKHandle.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKHandle.h"
@@ -75,11 +75,9 @@ static NSMutableDictionary* s_handleInstancesTable = nil;
 	NSString* key;
 
 	if (colour)
-#warning 64BIT: Check formatting arguments
-		key = [NSString stringWithFormat:@"%@_%@_%dx%d", classKey, [colour hexString], (NSInteger)ceil(size.width), (NSInteger)ceil(size.height)];
+		key = [NSString stringWithFormat:@"%@_%@_%ldx%ld", classKey, [colour hexString], (long)ceil(size.width), (long)ceil(size.height)];
 	else
-#warning 64BIT: Check formatting arguments
-		key = [NSString stringWithFormat:@"%@_%dx%d", classKey, (NSInteger)ceil(size.width), (NSInteger)ceil(size.height)];
+		key = [NSString stringWithFormat:@"%@_%ldx%ld", classKey, (long)ceil(size.width), (long)ceil(size.height)];
 
 	DKHandle* inst = nil;
 
@@ -266,7 +264,6 @@ static NSMutableDictionary* s_handleInstancesTable = nil;
 
 + (NSString*)keyForKnobType:(DKKnobType)type
 {
-#warning 64BIT: Check formatting arguments
 	return [NSString stringWithFormat:@"hnd_type_%d", type];
 }
 

--- a/framework/Code/DKHatching.h
+++ b/framework/Code/DKHatching.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKHatching.m
+++ b/framework/Code/DKHatching.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKHatching.h"

--- a/framework/Code/DKImageAdornment.h
+++ b/framework/Code/DKImageAdornment.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKImageAdornment.m
+++ b/framework/Code/DKImageAdornment.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKImageAdornment.h"
@@ -38,7 +38,6 @@
 	m_image = image;
 
 	//[_image setFlipped:YES];
-	[m_image setScalesWhenResized:YES];
 	[m_image setCacheMode:NSImageCacheNever];
 }
 

--- a/framework/Code/DKImageDataManager.h
+++ b/framework/Code/DKImageDataManager.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKImageDataManager.m
+++ b/framework/Code/DKImageDataManager.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKImageDataManager.h"
@@ -307,7 +307,6 @@ NSString* kDKImageDataManagerPasteboardType = @"net.apptree.drawkit.imgdatamgrty
 
 - (NSString*)checksumString
 {
-#warning 64BIT: Inspect use of long
 	return [NSString stringWithFormat:@"%ld", (long)[self checksum]];
 }
 

--- a/framework/Code/DKImageOverlayLayer.h
+++ b/framework/Code/DKImageOverlayLayer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKImageOverlayLayer.m
+++ b/framework/Code/DKImageOverlayLayer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKImageOverlayLayer.h"

--- a/framework/Code/DKImageShape.h
+++ b/framework/Code/DKImageShape.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape.h"

--- a/framework/Code/DKImageShape.m
+++ b/framework/Code/DKImageShape.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKImageShape.h"
@@ -223,7 +223,6 @@ NSString* kDKOriginalNameMetadataKey = @"dk_original_name";
 
 		[m_image setCacheMode:NSImageCacheNever];
 		[m_image recache];
-		[m_image setScalesWhenResized:YES];
 		[self notifyVisualChange];
 
 		// setting the image nils the key. Callers that know there is a key should use setImageWithKey:coder: instead.
@@ -445,7 +444,6 @@ NSString* kDKOriginalNameMetadataKey = @"dk_original_name";
 												 key:&newKey];
 
 		if (image) {
-			[image setScalesWhenResized:YES];
 			[image setCacheMode:NSImageCacheNever];
 
 			// keep a local reference to the data if possible

--- a/framework/Code/DKKeyedUnarchiver.h
+++ b/framework/Code/DKKeyedUnarchiver.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKKeyedUnarchiver.m
+++ b/framework/Code/DKKeyedUnarchiver.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKKeyedUnarchiver.h"

--- a/framework/Code/DKKnob.h
+++ b/framework/Code/DKKnob.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKKnob.m
+++ b/framework/Code/DKKnob.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKKnob.h"
@@ -330,12 +330,10 @@ static NSSize sKnobSize = { 6.0, 6.0 };
 	if (fontSize < 2.0)
 		fontSize = 2.0;
 
-	NSFont* font = [NSFont fontWithName:@"Monaco"
-								   size:fontSize];
+	NSFont* font = [NSFont userFixedPitchFontOfSize:fontSize];
 	[attrs setObject:font
 			  forKey:NSFontAttributeName];
 
-#warning 64BIT: Inspect use of long
 	NSString* s = [NSString stringWithFormat:@"%ld", (long)code];
 	NSRect box;
 

--- a/framework/Code/DKLayer+Metadata.h
+++ b/framework/Code/DKLayer+Metadata.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKLayer+Metadata.m
+++ b/framework/Code/DKLayer+Metadata.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer+Metadata.h"

--- a/framework/Code/DKLayer.h
+++ b/framework/Code/DKLayer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKLayer.m
+++ b/framework/Code/DKLayer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKLayerGroup.h
+++ b/framework/Code/DKLayerGroup.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKLayerGroup.m
+++ b/framework/Code/DKLayerGroup.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayerGroup.h"
@@ -371,7 +371,6 @@ NSString* kDKLayerGroupDidReorderLayers = @"kDKLayerGroupDidReorderLayers";
 		if (k == NSNotFound)
 			found = NO;
 		else
-#warning 64BIT: Inspect use of long
 			temp = [NSString stringWithFormat:@"%@ %ld", aName, (long)++numeral];
 	}
 
@@ -387,7 +386,6 @@ NSString* kDKLayerGroupDidReorderLayers = @"kDKLayerGroupDidReorderLayers";
  */
 - (DKLayer*)objectInLayersAtIndex:(NSUInteger)layerIndex
 {
-#warning 64BIT: Inspect use of long
 	NSAssert1(layerIndex < [self countOfLayers], @"bad layer index %ld (overrange)", (long)layerIndex);
 
 	return [[self layers] objectAtIndex:layerIndex];
@@ -869,8 +867,6 @@ NSString* kDKLayerGroupDidReorderLayers = @"kDKLayerGroupDidReorderLayers";
 				}
 				@catch (id exc)
 				{
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 					NSLog(@"exception while drawing layer %@ [%ld of %ld in group %@](%@ - ignored)", layer, (long)n, (long)[self countOfLayers], self, exc);
 				}
 				@finally

--- a/framework/Code/DKLinearObjectStorage.h
+++ b/framework/Code/DKLinearObjectStorage.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKLinearObjectStorage.m
+++ b/framework/Code/DKLinearObjectStorage.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLinearObjectStorage.h"

--- a/framework/Code/DKMetadataItem.h
+++ b/framework/Code/DKMetadataItem.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>
@@ -137,7 +137,9 @@ DKMetadataItems are used to store metadata (attribute) values in user info dicti
 - (NSString*)stringValue;
 - (NSAttributedString*)attributedStringValue;
 - (NSInteger)intValue;
+- (NSInteger)integerValue;
 - (CGFloat)floatValue;
+- (double)doubleValue;
 - (BOOL)boolValue;
 - (NSColor*)colourValue;
 - (NSSize)sizeValue;

--- a/framework/Code/DKMetadataItem.m
+++ b/framework/Code/DKMetadataItem.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKMetadataItem.h"
@@ -223,13 +223,10 @@ NSString* DKMultipleMetadataItemsPBoardType = @"com.apptree.dk.multimeta";
 
 		const char* eType = [value objCType];
 
-#warning 64BIT: Inspect use of @encode
 		if (strcmp(eType, @encode(NSInteger)) == 0)
 			return [self metadataItemWithInteger:[value integerValue]];
-#warning 64BIT: Inspect use of @encode
 		else if (strcmp(eType, @encode(double)) == 0 || strcmp(eType, @encode(CGFloat)) == 0)
 			return [self metadataItemWithReal:[value doubleValue]];
-#warning 64BIT: Inspect use of @encode
 		else if (strcmp(eType, @encode(NSUInteger)) == 0)
 			return [self metadataItemWithUnsigned:[value unsignedIntegerValue]];
 		else if (strcmp(eType, @encode(BOOL)) == 0)
@@ -642,7 +639,21 @@ NSString* DKMultipleMetadataItemsPBoardType = @"com.apptree.dk.multimeta";
 					  wasLossy:NULL] integerValue];
 }
 
+- (NSInteger)integerValue
+{
+	return [[self convertValue:[self value]
+						toType:DKMetadataTypeInteger
+					  wasLossy:NULL] integerValue];
+}
+
 - (CGFloat)floatValue
+{
+	return [[self convertValue:[self value]
+						toType:DKMetadataTypeReal
+					  wasLossy:NULL] doubleValue];
+}
+
+- (double)doubleValue
 {
 	return [[self convertValue:[self value]
 						toType:DKMetadataTypeReal
@@ -946,7 +957,6 @@ NSString* DKMultipleMetadataItemsPBoardType = @"com.apptree.dk.multimeta";
 		}
 
 	default:
-#warning 64BIT: Check formatting arguments
 		NSLog(@"an unknown type (%d) was passed to DKMetadataItem <%@> for conversion, value = %@", type, self, inValue);
 		break;
 	}

--- a/framework/Code/DKObjectCreationTool.h
+++ b/framework/Code/DKObjectCreationTool.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingTool.h"

--- a/framework/Code/DKObjectCreationTool.m
+++ b/framework/Code/DKObjectCreationTool.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectCreationTool.h"

--- a/framework/Code/DKObjectDrawingLayer+Alignment.h
+++ b/framework/Code/DKObjectDrawingLayer+Alignment.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectDrawingLayer.h"

--- a/framework/Code/DKObjectDrawingLayer+Alignment.m
+++ b/framework/Code/DKObjectDrawingLayer+Alignment.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectDrawingLayer+Alignment.h"

--- a/framework/Code/DKObjectDrawingLayer+Duplication.h
+++ b/framework/Code/DKObjectDrawingLayer+Duplication.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectDrawingLayer.h"

--- a/framework/Code/DKObjectDrawingLayer+Duplication.m
+++ b/framework/Code/DKObjectDrawingLayer+Duplication.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectDrawingLayer+Duplication.h"

--- a/framework/Code/DKObjectDrawingLayer.h
+++ b/framework/Code/DKObjectDrawingLayer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectOwnerLayer.h"

--- a/framework/Code/DKObjectDrawingLayer.m
+++ b/framework/Code/DKObjectDrawingLayer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectDrawingLayer.h"
@@ -184,8 +184,7 @@ enum {
 			[inv setSelector:selector];
 			[inv invokeWithTarget:o];
 
-#warning 64BIT: Inspect use of sizeof
-			if ([[inv methodSignature] methodReturnLength] <= sizeof(NSInteger))
+			if ([[inv methodSignature] methodReturnLength] <= (NSUInteger)(sizeof(NSInteger)))
 				[inv getReturnValue:&rval];
 
 			if (rval == answer)
@@ -2259,55 +2258,55 @@ static void drawFunction3(const void* value, void* context)
 		// anything to draw?
 
 		if ([self countOfObjects] > 0) {
-			NSAutoreleasePool* pool = [NSAutoreleasePool new];
+			@autoreleasepool {
 
 #if !FAST_DRAWING_ITERATION
-			NSEnumerator* iter;
-			DKDrawableObject* obj;
+				NSEnumerator* iter;
+				DKDrawableObject* obj;
 #endif
-			BOOL screen = [NSGraphicsContext currentContextDrawingToScreen];
-			BOOL drawSelected = [self selectionVisible] && screen && ([self isActive] || [[self class] selectionIsShownWhenInactive]) && ![self locked];
-			NSArray* objectsToDraw = [self objectsForUpdateRect:rect
-														 inView:aView];
+				BOOL screen = [NSGraphicsContext currentContextDrawingToScreen];
+				BOOL drawSelected = [self selectionVisible] && screen && ([self isActive] || [[self class] selectionIsShownWhenInactive]) && ![self locked];
+				NSArray* objectsToDraw = [self objectsForUpdateRect:rect
+															 inView:aView];
 
-			// draw the objects
+				// draw the objects
 
-			if (!drawSelected || [self drawsSelectionHighlightsOnTop]) {
+				if (!drawSelected || [self drawsSelectionHighlightsOnTop]) {
 #if FAST_DRAWING_ITERATION
-				CFArrayApplyFunction((CFArrayRef)objectsToDraw, CFRangeMake(0, [objectsToDraw count]), drawFunction1, aView);
+					CFArrayApplyFunction((CFArrayRef)objectsToDraw, CFRangeMake(0, [objectsToDraw count]), drawFunction1, aView);
 #else
-				iter = [objectsToDraw objectEnumerator];
+					iter = [objectsToDraw objectEnumerator];
 
-				while ((obj = [iter nextObject]))
-					[obj drawContentWithSelectedState:NO];
+					while ((obj = [iter nextObject]))
+						[obj drawContentWithSelectedState:NO];
 #endif
-			} else {
+				} else {
 #if FAST_DRAWING_ITERATION
-				CFArrayApplyFunction((CFArrayRef)objectsToDraw, CFRangeMake(0, [objectsToDraw count]), drawFunction3, self);
+					CFArrayApplyFunction((CFArrayRef)objectsToDraw, CFRangeMake(0, [objectsToDraw count]), drawFunction3, self);
 #else
-				iter = [objectsToDraw objectEnumerator];
+					iter = [objectsToDraw objectEnumerator];
 
-				while ((obj = [iter nextObject]))
-					[obj drawContentWithSelectedState:[self isSelectedObject:obj]];
+					while ((obj = [iter nextObject]))
+						[obj drawContentWithSelectedState:[self isSelectedObject:obj]];
 #endif
-			}
-
-			// draw the selection on top if set to do so
-
-			if ([self drawsSelectionHighlightsOnTop] && drawSelected) {
-#if FAST_DRAWING_ITERATION
-				CFArrayApplyFunction((CFArrayRef)objectsToDraw, CFRangeMake(0, [objectsToDraw count]), drawFunction2, self);
-#else
-				iter = [objectsToDraw objectEnumerator];
-
-				while ((obj = [iter nextObject])) {
-					if ([self isSelectedObject:obj])
-						[obj drawSelectedState];
 				}
-#endif
-			}
 
-			[pool drain];
+				// draw the selection on top if set to do so
+
+				if ([self drawsSelectionHighlightsOnTop] && drawSelected) {
+#if FAST_DRAWING_ITERATION
+					CFArrayApplyFunction((CFArrayRef)objectsToDraw, CFRangeMake(0, [objectsToDraw count]), drawFunction2, self);
+#else
+					iter = [objectsToDraw objectEnumerator];
+
+					while ((obj = [iter nextObject])) {
+						if ([self isSelectedObject:obj])
+							[obj drawSelectedState];
+					}
+#endif
+				}
+
+			}
 		}
 
 		// draw any pending object
@@ -2832,11 +2831,6 @@ static void drawFunction3(const void* value, void* context)
 
 	if (action == @selector(unionSelectedObjects:) || action == @selector(combineSelectedObjects:)) {
 		return ([self countOfSelectedAvailableObjects] > 1);
-	}
-
-	if (action == @selector(setBooleanOpsFittingPolicy:)) {
-		[item setState:((NSUInteger)[item tag] == [NSBezierPath pathUnflatteningPolicy]) ? NSOnState : NSOffState];
-		return [self respondsToSelector:action];
 	}
 
 	if (action == @selector(objectBringForward:) || action == @selector(objectBringToFront:)) {

--- a/framework/Code/DKObjectOwnerLayer.h
+++ b/framework/Code/DKObjectOwnerLayer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKLayer.h"

--- a/framework/Code/DKObjectOwnerLayer.m
+++ b/framework/Code/DKObjectOwnerLayer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKObjectOwnerLayer.h"
@@ -272,7 +272,6 @@ static DKLayerCacheOption sDefaultCacheOption = kDKLayerCacheNone;
 			[inv setSelector:selector];
 			[inv invokeWithTarget:o];
 
-#warning 64BIT: Inspect use of sizeof
 			if ([[inv methodSignature] methodReturnLength] <= sizeof(NSInteger))
 				[inv getReturnValue:&rval];
 

--- a/framework/Code/DKObjectStorageProtocol.h
+++ b/framework/Code/DKObjectStorageProtocol.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKPasteboardInfo.h
+++ b/framework/Code/DKPasteboardInfo.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKPasteboardInfo.m
+++ b/framework/Code/DKPasteboardInfo.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKPasteboardInfo.h"

--- a/framework/Code/DKPathDecorator.h
+++ b/framework/Code/DKPathDecorator.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKPathDecorator.m
+++ b/framework/Code/DKPathDecorator.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKPathDecorator.h"
@@ -62,8 +62,6 @@
 	m_image = image;
 
 	if (m_image != nil) {
-		[m_image setScalesWhenResized:YES];
-
 		// get any PDF image rep and retain it for later quick access
 
 		NSArray* reps = [m_image representations];

--- a/framework/Code/DKPathInsertDeleteTool.h
+++ b/framework/Code/DKPathInsertDeleteTool.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingTool.h"

--- a/framework/Code/DKPathInsertDeleteTool.m
+++ b/framework/Code/DKPathInsertDeleteTool.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKPathInsertDeleteTool.h"

--- a/framework/Code/DKPathPointHandle.h
+++ b/framework/Code/DKPathPointHandle.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKPathPointHandle.m
+++ b/framework/Code/DKPathPointHandle.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKPathPointHandle.h"

--- a/framework/Code/DKPrintDrawingView.h
+++ b/framework/Code/DKPrintDrawingView.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingView.h"

--- a/framework/Code/DKPrintDrawingView.m
+++ b/framework/Code/DKPrintDrawingView.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKPrintDrawingView.h"

--- a/framework/Code/DKQuartzBlendRastGroup.h
+++ b/framework/Code/DKQuartzBlendRastGroup.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRastGroup.h"

--- a/framework/Code/DKQuartzBlendRastGroup.m
+++ b/framework/Code/DKQuartzBlendRastGroup.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKQuartzBlendRastGroup.h"

--- a/framework/Code/DKQuartzCache.h
+++ b/framework/Code/DKQuartzCache.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKQuartzCache.m
+++ b/framework/Code/DKQuartzCache.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKQuartzCache.h"

--- a/framework/Code/DKRandom.h
+++ b/framework/Code/DKRandom.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKRandom.m
+++ b/framework/Code/DKRandom.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRandom.h"
@@ -13,7 +13,6 @@
 {
 // returns a random value between 0 and 1.
 
-#warning 64BIT: Inspect use of unsigned long
 	static unsigned long seed = 0;
 
 	if (seed == 0) {

--- a/framework/Code/DKRastGroup.h
+++ b/framework/Code/DKRastGroup.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKRastGroup.m
+++ b/framework/Code/DKRastGroup.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRastGroup.h"

--- a/framework/Code/DKRasterizer.h
+++ b/framework/Code/DKRasterizer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizerProtocol.h"

--- a/framework/Code/DKRasterizer.m
+++ b/framework/Code/DKRasterizer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKRasterizerProtocol.h
+++ b/framework/Code/DKRasterizerProtocol.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKRegularPolygonPath.h
+++ b/framework/Code/DKRegularPolygonPath.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawablePath.h"

--- a/framework/Code/DKRegularPolygonPath.m
+++ b/framework/Code/DKRegularPolygonPath.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRegularPolygonPath.h"
@@ -274,36 +274,30 @@ static CGFloat sAngleConstraint = 0.261799387799; // 15°
 		case kDKDrawingEntireObjectPart:
 		case kDKRegularPolyCentrePart:
 			gridPt = [self convertPointToDrawing:[self location]];
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"centre x: %.2f%@\ncentre y: %.2f%@", gridPt.x, abbrUnits, gridPt.y, abbrUnits];
 			break;
 
 		case kDKRegularPolyRotationPart:
 			val = [self angleInDegrees];
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"%.1f%C", val, 0xB0];
 			break;
 
 		case kDKRegularPolyTipSpreadPart:
 			val = [self tipSpread] * 100.0;
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"tip: %.0f%%", val];
 			break;
 
 		case kDKRegularPolyValleySpreadPart:
 			val = [self valleySpread] * 100.0;
-#warning 64BIT: Check formatting arguments
 			infoStr = [NSString stringWithFormat:@"valley: %.0f%%", val];
 			break;
 
 		default:
 			if (((pc - kDKRegularPolyFirstVertexPart) & 1) == 1) {
 				val = [self innerRadius] * 100.0;
-#warning 64BIT: Check formatting arguments
 				infoStr = [NSString stringWithFormat:@"radial ratio: %.0f%%", val];
 			} else {
 				val = [[self drawing] convertLength:[self radius]];
-#warning 64BIT: Check formatting arguments
 				infoStr = [NSString stringWithFormat:@"radius: %.2f%@", val, abbrUnits];
 			}
 			break;
@@ -737,7 +731,6 @@ static CGFloat sAngleConstraint = 0.261799387799; // 15°
 	NSMenuItem* item;
 
 	for (i = 3; i < 9; ++i) {
-#warning 64BIT: Inspect use of long
 		item = [sidesMenu addItemWithTitle:[NSString stringWithFormat:@"%ld", (long)i]
 									action:@selector(setNumberOfSidesWithTag:)
 							 keyEquivalent:@""];

--- a/framework/Code/DKReshapableShape.h
+++ b/framework/Code/DKReshapableShape.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape.h"

--- a/framework/Code/DKReshapableShape.m
+++ b/framework/Code/DKReshapableShape.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKReshapableShape.h"

--- a/framework/Code/DKRetriggerableTimer.h
+++ b/framework/Code/DKRetriggerableTimer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKRetriggerableTimer.m
+++ b/framework/Code/DKRetriggerableTimer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRetriggerableTimer.h"

--- a/framework/Code/DKRotationHandle.h
+++ b/framework/Code/DKRotationHandle.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKRotationHandle.m
+++ b/framework/Code/DKRotationHandle.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRotationHandle.h"

--- a/framework/Code/DKRoughStroke.h
+++ b/framework/Code/DKRoughStroke.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStroke.h"

--- a/framework/Code/DKRoughStroke.m
+++ b/framework/Code/DKRoughStroke.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRoughStroke.h"
@@ -30,7 +30,6 @@
 // place so that minor rounding errors when doing path transforms don't generate different keys. Do not rely on this format, or attempt
 // to interpret it.
 
-#warning 64BIT: Check formatting arguments
 	return [NSString stringWithFormat:@"%.1f.%.1f.%.1f.%.1f", [path bounds].size.width, [path bounds].size.height, [path length], [self width]];
 }
 

--- a/framework/Code/DKRouteFinder.h
+++ b/framework/Code/DKRouteFinder.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKRouteFinder.m
+++ b/framework/Code/DKRouteFinder.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRouteFinder.h"
@@ -188,20 +188,12 @@ static DKRouteAlgorithmType s_Algorithm = kDKUseNearestNeighbour; //kDKUseSimula
 
 		NSUInteger n = [array count] + 1;
 
-#warning 64BIT: Inspect use of sizeof
-#warning 64BIT: Inspect use of sizeof
 		mOrder = malloc(sizeof(NSInteger) * n);
 		NSInteger kludge = 1;
-#warning 64BIT: Inspect use of sizeof
-#warning 64BIT: Inspect use of sizeof
 		memset_pattern4(mOrder, &kludge, sizeof(NSInteger) * n);
 
 		if ((mAlgorithm & kDKUseSimulatedAnnealing) != 0) {
-#warning 64BIT: Inspect use of sizeof
-#warning 64BIT: Inspect use of sizeof
 			mX = malloc(sizeof(CGFloat) * n);
-#warning 64BIT: Inspect use of sizeof
-#warning 64BIT: Inspect use of sizeof
 			mY = malloc(sizeof(CGFloat) * n);
 
 			NSInteger k = 0;
@@ -452,25 +444,11 @@ static DKDirection directionOfAngle(const CGFloat angle)
 #pragma mark -
 #pragma mark - from Numerical Recipes in C(2nd ed.Ch 10. p448)
 
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 static NSInteger* ivector(long nl, long nh);
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 static void free_ivector(NSInteger* v, long nl, long nh);
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 static CGFloat ran3(long* idum);
-#warning 64BIT: Inspect use of unsigned long
-#warning 64BIT: Inspect use of unsigned long
 static NSInteger irbit1(unsigned long* iseed);
 static NSInteger metrop(CGFloat de, CGFloat t);
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 static CGFloat ran3(long* idum);
 static CGFloat revcst(CGFloat x[], CGFloat y[], NSInteger iorder[], NSInteger ncity, NSInteger n[]);
 static void reverse(NSInteger iorder[], NSInteger ncity, NSInteger n[]);
@@ -483,16 +461,10 @@ static void trnspt(NSInteger iorder[], NSInteger ncity, NSInteger n[]);
 
 /* allocate an int vector with subscript range v[nl..nh] */
 
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 NSInteger* ivector(long nl, long nh)
 {
 	NSInteger* v;
 
-#warning 64BIT: Inspect use of sizeof
-#warning 64BIT: Inspect use of sizeof
 	v = (NSInteger*)malloc((size_t)((nh - nl + 1 + NR_END) * sizeof(NSInteger)));
 	if (v != NULL)
 		return v - nl + NR_END;
@@ -502,10 +474,6 @@ NSInteger* ivector(long nl, long nh)
 
 /* free an int vector allocated with ivector() */
 
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 void free_ivector(NSInteger* v, long nl, long nh)
 {
 #pragma unused(nh)
@@ -518,17 +486,11 @@ void free_ivector(NSInteger* v, long nl, long nh)
 #define MZ 0
 #define FAC (1.0 / MBIG)
 
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 CGFloat ran3(long* idum)
 {
 	static NSInteger inext, inextp;
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 	static long ma[56];
 	static NSInteger iff = 0;
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 	long mj, mk;
 	NSInteger i, ii, k;
 
@@ -582,12 +544,8 @@ CGFloat ran3(long* idum)
 #define IB18 131072
 #define MASK (IB1 + IB2 + IB5)
 
-#warning 64BIT: Inspect use of unsigned long
-#warning 64BIT: Inspect use of unsigned long
 NSInteger irbit1(unsigned long* iseed)
 {
-#warning 64BIT: Inspect use of unsigned long
-#warning 64BIT: Inspect use of unsigned long
 	unsigned long newbit;
 
 	newbit = (*iseed & IB18) >> 17
@@ -617,11 +575,7 @@ CGFloat anneal(CGFloat x[], CGFloat y[], NSInteger iorder[], NSInteger ncity, NS
 	NSInteger i, j, k, nsucc, nn, idec;
 
 	static NSInteger n[7];
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 	static long idum = -1;
-#warning 64BIT: Inspect use of unsigned long
-#warning 64BIT: Inspect use of unsigned long
 	static unsigned long iseed = 111;
 	CGFloat path, de, t, previousPath;
 
@@ -677,7 +631,7 @@ CGFloat anneal(CGFloat x[], CGFloat y[], NSInteger iorder[], NSInteger ncity, NS
 			// Decide whether to do a segment reversal or transport.
 			if (idec == 0) {
 				// Do a transport.
-				n[3] = n[2] + (NSInteger)(abs(nn - 2) * ran3(&idum)) + 1;
+				n[3] = n[2] + (NSInteger)(labs(nn - 2) * ran3(&idum)) + 1;
 				n[3] = 1 + ((n[3] - 1) % ncity);
 
 				// Transport to a location not on the path.
@@ -858,8 +812,6 @@ t is a temperature determined by the annealing schedule.
 
 NSInteger metrop(CGFloat de, CGFloat t)
 {
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
 	static long gljdum = 1;
 
 	return de < 0.0 || ran3(&gljdum) < _CGFloatExp(-de / t);

--- a/framework/Code/DKRuntimeHelper.h
+++ b/framework/Code/DKRuntimeHelper.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKRuntimeHelper.m
+++ b/framework/Code/DKRuntimeHelper.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRuntimeHelper.h"
@@ -45,7 +45,6 @@
 	NSInteger i, numClasses = objc_getClassList(NULL, 0);
 
 	if (numClasses > 0) {
-#warning 64BIT: Inspect use of sizeof
 		buffer = malloc(sizeof(Class) * numClasses);
 
 		NSAssert(buffer != nil, @"couldn't allocate the buffer");
@@ -98,7 +97,6 @@
 	NSInteger i, numClasses = objc_getClassList(NULL, 0);
 
 	if (numClasses > 0) {
-#warning 64BIT: Inspect use of sizeof
 		buffer = malloc(sizeof(Class) * numClasses);
 
 		NSAssert(buffer != nil, @"couldn't allocate the buffer");
@@ -156,12 +154,11 @@ BOOL classIsSubclassOfClass(const Class aClass, const Class subclass)
 
 BOOL classIsImmediateSubclassOfClass(const Class aClass, const Class subclass)
 {
-	/*
-	Class	superClass = subclass->super_class;
+	
+	Class	superClass = class_getSuperclass(subclass);
 	
 	if( superClass != Nil )
-		return ( 0 == strcmp( aClass->name, superClass->name ));
+		return [NSStringFromClass(aClass) isEqualToString:NSStringFromClass(superClass)];
 	else
-*/
-	return NO;
+		return NO;
 }

--- a/framework/Code/DKSelectAndEditTool.h
+++ b/framework/Code/DKSelectAndEditTool.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingTool.h"

--- a/framework/Code/DKSelectAndEditTool.m
+++ b/framework/Code/DKSelectAndEditTool.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKSelectAndEditTool.h"
@@ -1049,67 +1049,66 @@ static void dragFunction_mouseUp(const void* obj, void* context)
 	DKObjectDrawingLayer* odl = (DKObjectDrawingLayer*)layer;
 	NSArray* sel;
 	DKDrawableObject* obj;
-	NSAutoreleasePool* pool = [NSAutoreleasePool new];
+	@autoreleasepool {
 
-	// the mouse has actually been dragged, so flag that
+		// the mouse has actually been dragged, so flag that
 
-	mMouseMoved = YES;
-	mLastPoint = p;
+		mMouseMoved = YES;
+		mLastPoint = p;
 
-	// depending on the mode, carry out the operation for a mousedragged event
-	@try
-	{
-		switch ([self operationMode]) {
-		case kDKEditToolInvalidMode:
-		default:
-			break;
+		// depending on the mode, carry out the operation for a mousedragged event
+		@try
+		{
+			switch ([self operationMode]) {
+			case kDKEditToolInvalidMode:
+			default:
+				break;
 
-		case kDKEditToolSelectionMode:
-			[self setMarqueeRect:NSRectFromTwoPoints(mAnchorPoint, p)
-						 inLayer:odl];
+			case kDKEditToolSelectionMode:
+				[self setMarqueeRect:NSRectFromTwoPoints(mAnchorPoint, p)
+							 inLayer:odl];
 
-			sel = [odl objectsInRect:[self marqueeRect]];
+				sel = [odl objectsInRect:[self marqueeRect]];
 
-			if (extended)
-				[odl addObjectsToSelectionFromArray:sel];
-			else
-				[odl exchangeSelectionWithObjectsFromArray:sel];
+				if (extended)
+					[odl addObjectsToSelectionFromArray:sel];
+				else
+					[odl exchangeSelectionWithObjectsFromArray:sel];
 
-			break;
+				break;
 
-		case kDKEditToolMoveObjectsMode:
-			sel = [self draggedObjects];
+			case kDKEditToolMoveObjectsMode:
+				sel = [self draggedObjects];
 
-			if ([sel count] > 0) {
-				[aDel toolWillPerformUndoableAction:self];
-				[self dragObjectsAsGroup:sel
-								 inLayer:odl
-								 toPoint:p
-								   event:event
-							   dragPhase:kDKDragMouseDragged];
-				mPerformedUndoableTask = YES;
+				if ([sel count] > 0) {
+					[aDel toolWillPerformUndoableAction:self];
+					[self dragObjectsAsGroup:sel
+									 inLayer:odl
+									 toPoint:p
+									   event:event
+								   dragPhase:kDKDragMouseDragged];
+					mPerformedUndoableTask = YES;
+				}
+				break;
+
+			case kDKEditToolEditObjectMode:
+				obj = [odl singleSelection];
+				if (obj != nil) {
+					[aDel toolWillPerformUndoableAction:self];
+					[obj mouseDraggedAtPoint:p
+									  inPart:pc
+									   event:event];
+					mPerformedUndoableTask = YES;
+				}
+				break;
 			}
-			break;
-
-		case kDKEditToolEditObjectMode:
-			obj = [odl singleSelection];
-			if (obj != nil) {
-				[aDel toolWillPerformUndoableAction:self];
-				[obj mouseDraggedAtPoint:p
-								  inPart:pc
-								   event:event];
-				mPerformedUndoableTask = YES;
-			}
-			break;
 		}
-	}
-	@catch (NSException* exception)
-	{
-#warning 64BIT: Inspect use of long
-		NSLog(@"#### exception while dragging with selection tool: mode = %ld, exc = (%@) - ignored ####", (long)[self operationMode], exception);
-	}
+		@catch (NSException* exception)
+		{
+			NSLog(@"#### exception while dragging with selection tool: mode = %ld, exc = (%@) - ignored ####", (long)[self operationMode], exception);
+		}
 
-	[pool drain];
+	}
 }
 
 /** @brief Handle the mouse up event

--- a/framework/Code/DKSelectionPDFView.h
+++ b/framework/Code/DKSelectionPDFView.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawingView.h"

--- a/framework/Code/DKSelectionPDFView.m
+++ b/framework/Code/DKSelectionPDFView.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKSelectionPDFView.h"

--- a/framework/Code/DKShapeCluster.h
+++ b/framework/Code/DKShapeCluster.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKShapeGroup.h"

--- a/framework/Code/DKShapeCluster.m
+++ b/framework/Code/DKShapeCluster.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKShapeCluster.h"

--- a/framework/Code/DKShapeFactory.h
+++ b/framework/Code/DKShapeFactory.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKShapeFactory.m
+++ b/framework/Code/DKShapeFactory.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKShapeFactory.h"

--- a/framework/Code/DKShapeGroup.h
+++ b/framework/Code/DKShapeGroup.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape.h"

--- a/framework/Code/DKShapeGroup.m
+++ b/framework/Code/DKShapeGroup.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKShapeGroup.h"

--- a/framework/Code/DKStroke.h
+++ b/framework/Code/DKStroke.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKStroke.m
+++ b/framework/Code/DKStroke.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStroke.h"

--- a/framework/Code/DKStrokeDash.h
+++ b/framework/Code/DKStrokeDash.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKStrokeDash.m
+++ b/framework/Code/DKStrokeDash.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStrokeDash.h"
@@ -80,8 +80,7 @@ static NSUInteger euclid_hcf(NSUInteger a, NSUInteger b)
 	hcf = (CGFloat)euclid_hcf(a, b);
 	rem = fmod(halfLen, hcf);
 
-#warning 64BIT: Check formatting arguments
-	NSLog(@"size = %@, hcf = %f, rem = %f, halfLen = %f", NSStringFromSize(aSize), hcf, rem, halfLen);
+	//NSLog(@"size = %@, hcf = %f, rem = %f, halfLen = %f", NSStringFromSize(aSize), hcf, rem, halfLen);
 
 	if (rem > (hcf * 0.5f))
 		halfLen += (hcf - rem);
@@ -110,9 +109,7 @@ static NSUInteger euclid_hcf(NSUInteger a, NSUInteger b)
 #pragma mark -
 - (id)initWithPattern:(CGFloat[])dashes count:(NSInteger)count
 {
-#warning 64BIT: Inspect use of sizeof
-#warning 64BIT: Inspect use of sizeof
-	NSAssert(sizeof(dashes) <= 8 * sizeof(CGFloat), @"Expected dashes to be no more than 8 floats");
+	NSAssert((NSUInteger)(sizeof(dashes)) <= (NSUInteger)(8 * sizeof(CGFloat)), @"Expected dashes to be no more than 8 floats");
 	self = [super init];
 	if (self != nil) {
 		[self setDashPattern:dashes
@@ -360,9 +357,7 @@ static NSUInteger euclid_hcf(NSUInteger a, NSUInteger b)
 		m_pattern[0] = 5.0;
 		m_pattern[1] = 5.0;
 // Catch if someone changes the array size without considering the init method.
-#warning 64BIT: Inspect use of sizeof
-#warning 64BIT: Inspect use of sizeof
-		NSAssert(sizeof(m_pattern) == 8 * sizeof(CGFloat), @"init expects the m_pattern array to only be 8 floats");
+		NSAssert((NSUInteger)(sizeof(m_pattern)) == (NSUInteger)(8 * sizeof(CGFloat)), @"init expects the m_pattern array to only be 8 floats");
 		m_count = 2;
 		m_scaleToLineWidth = YES;
 	}
@@ -384,8 +379,6 @@ static NSUInteger euclid_hcf(NSUInteger a, NSUInteger b)
 - (void)encodeWithCoder:(NSCoder*)coder
 {
 	NSAssert(coder != nil, @"Expected valid coder");
-#warning 64BIT: Make sure values being encoded correspond to the types
-#warning 64BIT: Inspect use of @encode
 	[coder encodeArrayOfObjCType:@encode(CGFloat)
 						   count:[self count]
 							  at:m_pattern];
@@ -407,8 +400,6 @@ static NSUInteger euclid_hcf(NSUInteger a, NSUInteger b)
 		if (m_count > 8)
 			m_count = 8;
 
-#warning 64BIT: Make sure values being decoded correspond to the types
-#warning 64BIT: Inspect use of @encode
 		[coder decodeArrayOfObjCType:@encode(CGFloat)
 							   count:m_count
 								  at:m_pattern];

--- a/framework/Code/DKStyle+SimpleAccess.h
+++ b/framework/Code/DKStyle+SimpleAccess.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStyle.h"

--- a/framework/Code/DKStyle+SimpleAccess.m
+++ b/framework/Code/DKStyle+SimpleAccess.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStyle+SimpleAccess.h"

--- a/framework/Code/DKStyle+Text.h
+++ b/framework/Code/DKStyle+Text.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStyle.h"

--- a/framework/Code/DKStyle+Text.m
+++ b/framework/Code/DKStyle+Text.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStyle+Text.h"
@@ -69,7 +69,6 @@ static NSString* kDKBasicTextStyleDefaultKey = @"326CF635-7863-42C6-900D-CFFC7D5
  */
 + (NSString*)styleNameForFont:(NSFont*)font
 {
-#warning 64BIT: Check formatting arguments
 	return [NSString stringWithFormat:@"%@ %.1fpt", [font displayName], [font pointSize]];
 }
 

--- a/framework/Code/DKStyle.h
+++ b/framework/Code/DKStyle.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRastGroup.h"

--- a/framework/Code/DKStyleReader.h
+++ b/framework/Code/DKStyleReader.h
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKEvaluator.h"

--- a/framework/Code/DKStyleReader.m
+++ b/framework/Code/DKStyleReader.m
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStyleReader.h"

--- a/framework/Code/DKStyleRegistry.h
+++ b/framework/Code/DKStyleRegistry.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKStyleRegistry.m
+++ b/framework/Code/DKStyleRegistry.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStyleRegistry.h"
@@ -672,7 +672,6 @@ static BOOL s_NoDKDefaults = NO;
 		if (k == NSNotFound)
 			found = NO;
 		else
-#warning 64BIT: Inspect use of long
 			temp = [NSString stringWithFormat:@"%@ %ld", name, (long)++numeral];
 	}
 
@@ -1004,7 +1003,6 @@ static BOOL s_NoDKDefaults = NO;
 													  type:kDKStyleSwatchAutomatic] copy];
 
 			if (swatch != nil) {
-				[swatch setScalesWhenResized:YES];
 				[swatch setSize:NSMakeSize(28, 28)];
 				[swatch lockFocus];
 				[[NSGraphicsContext currentContext] setImageInterpolation:NSImageInterpolationLow];

--- a/framework/Code/DKSweptAngleGradient.h
+++ b/framework/Code/DKSweptAngleGradient.h
@@ -1,13 +1,12 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKGradient.h"
 
 typedef union {
-#warning 64BIT: Inspect use of unsigned long
 	unsigned long pixel;
 	struct
 		{

--- a/framework/Code/DKSweptAngleGradient.m
+++ b/framework/Code/DKSweptAngleGradient.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKSweptAngleGradient.h"
@@ -58,7 +58,6 @@
 	if (m_sa_colours)
 		free(m_sa_colours);
 
-#warning 64BIT: Inspect use of sizeof
 	m_sa_colours = malloc(sizeof(pix_int) * m_sa_segments);
 
 	if (m_sa_colours) {
@@ -122,8 +121,6 @@
 		cp.y *= 1.5;
 		twopi = 2 * pi;
 
-#warning 64BIT: Inspect use of unsigned long
-#warning 64BIT: Inspect use of unsigned long
 		unsigned long* p = (unsigned long*)buffer;
 
 		for (y = 0; y < height; ++y) {

--- a/framework/Code/DKTargetHandle.h
+++ b/framework/Code/DKTargetHandle.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKTargetHandle.m
+++ b/framework/Code/DKTargetHandle.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKTargetHandle.h"

--- a/framework/Code/DKTextAdornment.h
+++ b/framework/Code/DKTextAdornment.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKRasterizer.h"

--- a/framework/Code/DKTextAdornment.m
+++ b/framework/Code/DKTextAdornment.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKTextAdornment.h"

--- a/framework/Code/DKTextPath.h
+++ b/framework/Code/DKTextPath.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawablePath.h"

--- a/framework/Code/DKTextPath.m
+++ b/framework/Code/DKTextPath.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKTextPath.h"

--- a/framework/Code/DKTextShape.h
+++ b/framework/Code/DKTextShape.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKDrawableShape.h"

--- a/framework/Code/DKTextShape.m
+++ b/framework/Code/DKTextShape.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKTextShape.h"

--- a/framework/Code/DKTextSubstitutor.h
+++ b/framework/Code/DKTextSubstitutor.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKTextSubstitutor.m
+++ b/framework/Code/DKTextSubstitutor.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKTextSubstitutor.h"

--- a/framework/Code/DKToolController.h
+++ b/framework/Code/DKToolController.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKViewController.h"

--- a/framework/Code/DKToolController.m
+++ b/framework/Code/DKToolController.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKToolController.h"

--- a/framework/Code/DKToolRegistry.h
+++ b/framework/Code/DKToolRegistry.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKToolRegistry.m
+++ b/framework/Code/DKToolRegistry.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKToolRegistry.h"

--- a/framework/Code/DKUnarchivingHelper.h
+++ b/framework/Code/DKUnarchivingHelper.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKUnarchivingHelper.m
+++ b/framework/Code/DKUnarchivingHelper.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKUnarchivingHelper.h"

--- a/framework/Code/DKUndoManager.h
+++ b/framework/Code/DKUndoManager.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Foundation/Foundation.h>

--- a/framework/Code/DKUndoManager.m
+++ b/framework/Code/DKUndoManager.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKUndoManager.h"

--- a/framework/Code/DKUniqueID.h
+++ b/framework/Code/DKUniqueID.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKUniqueID.m
+++ b/framework/Code/DKUniqueID.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKUniqueID.h"

--- a/framework/Code/DKViewController.h
+++ b/framework/Code/DKViewController.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKViewController.m
+++ b/framework/Code/DKViewController.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKViewController.h"
@@ -904,7 +904,6 @@ static NSTimer* s_autoscrollTimer = nil;
 		BOOL vis = [[[self drawing] gridLayer] visible];
 		NSString* gridName = [[[self drawing] gridLayer] layerName];
 		NSString* itemRoot = vis ? NSLocalizedString(@"Hide %@", "menu item for Hide <layer name>") : NSLocalizedString(@"Show %@", @"menu item for Show <layer name>");
-#warning 64BIT: Check formatting arguments
 		NSString* title = [NSString stringWithFormat:itemRoot, gridName];
 
 		[item setTitle:title];
@@ -915,7 +914,6 @@ static NSTimer* s_autoscrollTimer = nil;
 		BOOL vis = [[[self drawing] guideLayer] visible];
 		NSString* gridName = [[[self drawing] guideLayer] layerName];
 		NSString* itemRoot = vis ? NSLocalizedString(@"Hide %@", "menu item for Hide <layer name>") : NSLocalizedString(@"Show %@", @"menu item for Show <layer name>");
-#warning 64BIT: Check formatting arguments
 		NSString* title = [NSString stringWithFormat:itemRoot, gridName];
 
 		[item setTitle:title];

--- a/framework/Code/DKZigZagFill.h
+++ b/framework/Code/DKZigZagFill.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKFill.h"

--- a/framework/Code/DKZigZagFill.m
+++ b/framework/Code/DKZigZagFill.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKZigZagFill.h"

--- a/framework/Code/DKZigZagStroke.h
+++ b/framework/Code/DKZigZagStroke.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKStroke.h"

--- a/framework/Code/DKZigZagStroke.m
+++ b/framework/Code/DKZigZagStroke.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKZigZagStroke.h"

--- a/framework/Code/DKZoomTool.h
+++ b/framework/Code/DKZoomTool.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/DKZoomTool.m
+++ b/framework/Code/DKZoomTool.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKZoomTool.h"

--- a/framework/Code/GCInfoFloater.h
+++ b/framework/Code/GCInfoFloater.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/GCInfoFloater.m
+++ b/framework/Code/GCInfoFloater.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCInfoFloater.h"

--- a/framework/Code/GCObservableObject.h
+++ b/framework/Code/GCObservableObject.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/GCObservableObject.m
+++ b/framework/Code/GCObservableObject.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCObservableObject.h"
@@ -22,12 +22,13 @@ static NSMutableDictionary* sActionNameRegistry = nil;
 	if (sActionNameRegistry == nil)
 		sActionNameRegistry = [[NSMutableDictionary alloc] init];
 
-	NSMutableDictionary* sd = [sActionNameRegistry objectForKey:cl];
+	NSString* className = NSStringFromClass(cl);
+	NSMutableDictionary* sd = [sActionNameRegistry objectForKey:className];
 
 	if (sd == nil) {
 		sd = [[NSMutableDictionary alloc] init];
 		[sActionNameRegistry setObject:sd
-								forKey:cl];
+								forKey:className];
 		[sd release];
 	}
 
@@ -37,7 +38,7 @@ static NSMutableDictionary* sActionNameRegistry = nil;
 
 + (NSString*)actionNameForKeyPath:(NSString*)kp objClass:(Class)cl
 {
-	NSDictionary* sd = [sActionNameRegistry objectForKey:cl];
+	NSDictionary* sd = [sActionNameRegistry objectForKey:NSStringFromClass(cl)];
 	NSString* an = [sd objectForKey:kp];
 
 	if (an)

--- a/framework/Code/GCOneShotEffectTimer.h
+++ b/framework/Code/GCOneShotEffectTimer.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/GCOneShotEffectTimer.m
+++ b/framework/Code/GCOneShotEffectTimer.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCOneShotEffectTimer.h"

--- a/framework/Code/GCThreadQueue.h
+++ b/framework/Code/GCThreadQueue.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/GCThreadQueue.m
+++ b/framework/Code/GCThreadQueue.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCThreadQueue.h"

--- a/framework/Code/GCUndoManager.h
+++ b/framework/Code/GCUndoManager.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/GCUndoManager.m
+++ b/framework/Code/GCUndoManager.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCUndoManager.h"
@@ -851,8 +851,7 @@
 			else
 				selString = @"<subgroup>";
 
-#warning 64BIT: Check formatting arguments
-			[newTaskGroup setActionName:[NSString stringWithFormat:@"%@ (%d: %@)", [topGroup actionName], ++suffix, selString]];
+			[newTaskGroup setActionName:[NSString stringWithFormat:@"%@ (%lu: %@)", [topGroup actionName], (unsigned long)++suffix, selString]];
 			[self pushGroupOntoUndoStack:newTaskGroup];
 			[newTaskGroup release];
 		}
@@ -915,8 +914,7 @@
 
 - (NSString*)description
 {
-#warning 64BIT: Check formatting arguments
-	return [NSString stringWithFormat:@"%@ g-level = %d, u-stack: %@, r-stack: %@", [super description], [self groupingLevel], [self undoStack], [self redoStack]];
+	return [NSString stringWithFormat:@"%@ g-level = %lu, u-stack: %@, r-stack: %@", [super description], (unsigned long)[self groupingLevel], [self undoStack], [self redoStack]];
 }
 
 @end
@@ -958,7 +956,7 @@
 
 - (GCUndoTask*)taskAtIndex:(NSUInteger)indx
 {
-	THROW_IF_FALSE2(indx < [[self tasks] count], @"invalid task index (%d) in group %@", indx, self);
+	THROW_IF_FALSE2(indx < [[self tasks] count], @"invalid task index (%ld) in group %@", (long)indx, self);
 
 	return [[self tasks] objectAtIndex:indx];
 }
@@ -1104,8 +1102,7 @@
 
 - (NSString*)description
 {
-#warning 64BIT: Check formatting arguments
-	return [NSString stringWithFormat:@"%@ '%@' %d tasks: %@", [super description], [self actionName], [mTasks count], mTasks];
+	return [NSString stringWithFormat:@"%@ '%@' %lu tasks: %@", [super description], [self actionName], (unsigned long)[mTasks count], mTasks];
 }
 
 @end
@@ -1223,8 +1220,7 @@
 
 - (NSString*)description
 {
-#warning 64BIT: Check formatting arguments
-	return [NSString stringWithFormat:@"%@ target = <%@ 0x%x>, selector: %@", [super description], NSStringFromClass([[self target] class]), [self target], NSStringFromSelector([mInvocation selector])];
+	return [NSString stringWithFormat:@"%@ target = <%@ %p>, selector: %@", [super description], NSStringFromClass([[self target] class]), [self target], NSStringFromSelector([mInvocation selector])];
 }
 
 @end

--- a/framework/Code/GCZoomView.h
+++ b/framework/Code/GCZoomView.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/GCZoomView.m
+++ b/framework/Code/GCZoomView.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "GCZoomView.h"

--- a/framework/Code/NSAffineTransform+DKAdditions.h
+++ b/framework/Code/NSAffineTransform+DKAdditions.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSAffineTransform+DKAdditions.m
+++ b/framework/Code/NSAffineTransform+DKAdditions.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSAffineTransform+DKAdditions.h"

--- a/framework/Code/NSAttributedString+DKAdditions.h
+++ b/framework/Code/NSAttributedString+DKAdditions.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSAttributedString+DKAdditions.m
+++ b/framework/Code/NSAttributedString+DKAdditions.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSAttributedString+DKAdditions.h"

--- a/framework/Code/NSBezierPath+Combinatorial.h
+++ b/framework/Code/NSBezierPath+Combinatorial.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSBezierPath+Combinatorial.m
+++ b/framework/Code/NSBezierPath+Combinatorial.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSBezierPath+Combinatorial.h"
@@ -61,7 +61,6 @@
 		[blob fill];
 // label it so we can see the order
 
-#warning 64BIT: Inspect use of long
 		NSString* str = [NSString stringWithFormat:@"%ld", (long)i];
 		[str drawAtPoint:blobRect.origin
 			withAttributes:nil];
@@ -114,8 +113,7 @@
 
 	pointForClosure = [path currentpointForSegment:0];
 
-#warning 64BIT: Inspect use of long
-	NSLog(@"appending in range %@, max = %ld", NSStringFromRange(range), (long)m);
+	//NSLog(@"appending in range %@, max = %ld", NSStringFromRange(range), (long)m);
 
 	if (range.location >= (NSUInteger)[path elementCount])
 		return;
@@ -160,9 +158,7 @@
 	NSAssert(firstIndex >= 0, @"index value is negative");
 	NSAssert(nextIndex >= 0, @"index value is negative");
 
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
-	NSLog(@"appending elements from %ld to %ld", (long)firstIndex, (long)nextIndex);
+	//NSLog(@"appending elements from %ld to %ld", (long)firstIndex, (long)nextIndex);
 
 	BOOL isWrapping = (nextIndex < firstIndex);
 

--- a/framework/Code/NSBezierPath+Editing.h
+++ b/framework/Code/NSBezierPath+Editing.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSBezierPath+Editing.m
+++ b/framework/Code/NSBezierPath+Editing.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSBezierPath+Editing.h"

--- a/framework/Code/NSBezierPath+Geometry.h
+++ b/framework/Code/NSBezierPath+Geometry.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSBezierPath+Geometry.m
+++ b/framework/Code/NSBezierPath+Geometry.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSBezierPath+Geometry.h"

--- a/framework/Code/NSBezierPath+Shapes.h
+++ b/framework/Code/NSBezierPath+Shapes.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSBezierPath+Shapes.m
+++ b/framework/Code/NSBezierPath+Shapes.m
@@ -1,14 +1,14 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSBezierPath+Shapes.h"
 #import "NSBezierPath+Geometry.h"
 
-#pragma mark Contants(Non - localized)
-static const CGFloat deg60 = 1.0471975512;
+#pragma mark Constants(Non - localized)
+//static const CGFloat deg60 = 1.0471975512;
 static const CGFloat sin60 = 0.8660254038;
 
 @implementation NSBezierPath (Shapes)

--- a/framework/Code/NSBezierPath+Text.h
+++ b/framework/Code/NSBezierPath+Text.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSBezierPath+Text.m
+++ b/framework/Code/NSBezierPath+Text.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSBezierPath+Text.h"
@@ -370,74 +370,74 @@ static NSDictionary* s_TOPTextAttributes = nil;
 		// lay down the glyphs along the path
 
 		for (glyphIndex = glyphRange.location; glyphIndex < NSMaxRange(glyphRange); ++glyphIndex) {
-			NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+			@autoreleasepool {
 
-			NSRect lineFragmentRect = [lm lineFragmentRectForGlyphAtIndex:glyphIndex
-														   effectiveRange:NULL];
-			NSPoint viewLocation, layoutLocation = [lm locationForGlyphAtIndex:glyphIndex];
+				NSRect lineFragmentRect = [lm lineFragmentRectForGlyphAtIndex:glyphIndex
+															   effectiveRange:NULL];
+				NSPoint viewLocation, layoutLocation = [lm locationForGlyphAtIndex:glyphIndex];
 
-			// if this represents anything other than the first line, ignore it
+				// if this represents anything other than the first line, ignore it
 
-			if (lineFragmentRect.origin.y > 0.0) {
-				result = NO;
-				break;
-			}
-
-			gbr = [lm boundingRectForGlyphRange:NSMakeRange(glyphIndex, 1)
-								inTextContainer:tc];
-			CGFloat half = NSWidth(gbr) * 0.5f;
-
-			// if the character width is zero or -ve, skip it - some control glyphs appear to need suppressing in this way.
-			// Note that this prevents some kinds of accents from getting drawn - need to work out a fix for that.
-
-			if (half > 0) {
-				// get a shortened path that starts at the character location
-
-				temp = [self bezierPathByTrimmingFromLength:NSMinX(lineFragmentRect) + layoutLocation.x + half];
-
-				// if no more room on path, stop laying glyphs
-
-				if ([temp length] < half) {
+				if (lineFragmentRect.origin.y > 0.0) {
 					result = NO;
 					break;
 				}
 
-				[temp elementAtIndex:0
-					associatedPoints:&viewLocation];
-				CGFloat angle = [temp slopeStartingPath];
+				gbr = [lm boundingRectForGlyphRange:NSMakeRange(glyphIndex, 1)
+									inTextContainer:tc];
+				CGFloat half = NSWidth(gbr) * 0.5f;
 
-				// view location needs to be offset vertically normal to the path to account for the baseline
+				// if the character width is zero or -ve, skip it - some control glyphs appear to need suppressing in this way.
+				// Note that this prevents some kinds of accents from getting drawn - need to work out a fix for that.
 
-				baseline = NSHeight(gbr) - [[lm typesetter] baselineOffsetInLayoutManager:lm
-																			   glyphIndex:glyphIndex];
+				if (half > 0) {
+					// get a shortened path that starts at the character location
 
-				viewLocation.x -= baseline * cosf(angle + NINETY_DEGREES);
-				viewLocation.y -= baseline * sinf(angle + NINETY_DEGREES);
+					temp = [self bezierPathByTrimmingFromLength:NSMinX(lineFragmentRect) + layoutLocation.x + half];
 
-				// view location needs to be projected back along the baseline tangent by half the character width to align
-				// the character based on the middle of the glyph instead of the left edge
+					// if no more room on path, stop laying glyphs
 
-				viewLocation.x -= half * cosf(angle);
-				viewLocation.y -= half * sinf(angle);
+					if ([temp length] < half) {
+						result = NO;
+						break;
+					}
 
-				// cache the glyph positioning information to avoid recalculation next time round
+					[temp elementAtIndex:0
+						associatedPoints:&viewLocation];
+					CGFloat angle = [temp slopeStartingPath];
 
-				posInfo = [[DKPathGlyphInfo alloc] initWithGlyphIndex:glyphIndex
-															 position:viewLocation
-																slope:angle];
-				[newGlyphCache addObject:posInfo];
-				[posInfo release];
+					// view location needs to be offset vertically normal to the path to account for the baseline
 
-				// call the helper object to finish off what we intend to do with this glyph
+					baseline = NSHeight(gbr) - [[lm typesetter] baselineOffsetInLayoutManager:lm
+																				   glyphIndex:glyphIndex];
 
-				[helperObject layoutManager:lm
-					  willPlaceGlyphAtIndex:glyphIndex
-								 atLocation:viewLocation
-								  pathAngle:angle
-									yOffset:dy];
+					viewLocation.x -= baseline * cosf(angle + NINETY_DEGREES);
+					viewLocation.y -= baseline * sinf(angle + NINETY_DEGREES);
+
+					// view location needs to be projected back along the baseline tangent by half the character width to align
+					// the character based on the middle of the glyph instead of the left edge
+
+					viewLocation.x -= half * cosf(angle);
+					viewLocation.y -= half * sinf(angle);
+
+					// cache the glyph positioning information to avoid recalculation next time round
+
+					posInfo = [[DKPathGlyphInfo alloc] initWithGlyphIndex:glyphIndex
+																 position:viewLocation
+																	slope:angle];
+					[newGlyphCache addObject:posInfo];
+					[posInfo release];
+
+					// call the helper object to finish off what we intend to do with this glyph
+
+					[helperObject layoutManager:lm
+						  willPlaceGlyphAtIndex:glyphIndex
+									 atLocation:viewLocation
+									  pathAngle:angle
+										yOffset:dy];
+				}
+
 			}
-
-			[pool drain];
 		}
 
 		[cache setObject:newGlyphCache
@@ -661,7 +661,6 @@ static NSDictionary* s_TOPTextAttributes = nil;
 // see if the path we need is cached, in which case we can avoid recomputing it. Because there could be several different paths that apply to ranges,
 // the cache key is generated from the various parameters
 
-#warning 64BIT: Check formatting arguments
 	NSString* pathKey = [NSString stringWithFormat:@"DKUnderlinePath_%@_%.2f", NSStringFromRange(range), dy];
 	ulp = [cache objectForKey:pathKey];
 
@@ -701,7 +700,6 @@ static NSDictionary* s_TOPTextAttributes = nil;
 		// be possible.
 
 		NSArray* descenderBreaks;
-#warning 64BIT: Check formatting arguments
 		NSString* breaksKey = [NSString stringWithFormat:@"DKUnderlineBreaks_%@_%.2f", NSStringFromRange(range), ulOffset];
 		descenderBreaks = [cache objectForKey:breaksKey];
 
@@ -800,7 +798,6 @@ static NSDictionary* s_TOPTextAttributes = nil;
 
 // see if we can reuse a previously cached path here
 
-#warning 64BIT: Check formatting arguments
 	NSString* pathKey = [NSString stringWithFormat:@"DKStrikethroughPath_%@_%.2f", NSStringFromRange(range), dy];
 	ulp = [cache objectForKey:pathKey];
 
@@ -1599,78 +1596,78 @@ static NSInteger SortPointsHorizontally(NSValue* value1, NSValue* value2, void* 
 	NSInteger lineCount = (floor(NSHeight(br) / lineHeight)) + 1;
 
 	if (lineCount > 0) {
-		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-		NSArray* previousLine = nil;
-		NSArray* currentLine;
-		NSInteger i;
-		CGFloat linePosition = NSMinY(br);
-		NSRect lineRect;
+		@autoreleasepool {
+			NSArray* previousLine = nil;
+			NSArray* currentLine;
+			NSInteger i;
+			CGFloat linePosition = NSMinY(br);
+			NSRect lineRect;
 
-		lineRect.size.height = lineHeight;
+			lineRect.size.height = lineHeight;
 
-		for (i = 0; i < lineCount; ++i) {
-			lineRect.origin.y = linePosition;
+			for (i = 0; i < lineCount; ++i) {
+				lineRect.origin.y = linePosition;
 
-			if (i == 0)
-				previousLine = [self intersectingPointsWithHorizontalLineAtY:linePosition + 1];
-			else {
-				linePosition = NSMinY(br) + (i * lineHeight);
-				currentLine = [self intersectingPointsWithHorizontalLineAtY:linePosition];
+				if (i == 0)
+					previousLine = [self intersectingPointsWithHorizontalLineAtY:linePosition + 1];
+				else {
+					linePosition = NSMinY(br) + (i * lineHeight);
+					currentLine = [self intersectingPointsWithHorizontalLineAtY:linePosition];
 
-				if (currentLine != nil) {
-					// go through the points of the previous line and this one, forming rects
-					// by taking the inner points
+					if (currentLine != nil) {
+						// go through the points of the previous line and this one, forming rects
+						// by taking the inner points
 
-					NSUInteger j, ur, lr, rectsOnLine;
+						NSUInteger j, ur, lr, rectsOnLine;
 
-					ur = [previousLine count];
-					lr = [currentLine count];
+						ur = [previousLine count];
+						lr = [currentLine count];
 
-					rectsOnLine = MAX(ur, lr);
+						rectsOnLine = MAX(ur, lr);
 
-					for (j = 0; j < rectsOnLine; ++j) {
-						NSPoint upper, lower;
+						for (j = 0; j < rectsOnLine; ++j) {
+							NSPoint upper, lower;
 
-						upper = [[previousLine objectAtIndex:j % ur] pointValue];
-						lower = [[currentLine objectAtIndex:j % lr] pointValue];
+							upper = [[previousLine objectAtIndex:j % ur] pointValue];
+							lower = [[currentLine objectAtIndex:j % lr] pointValue];
 
-						// even values of j are left edges, odd values are right edges
+							// even values of j are left edges, odd values are right edges
 
-						if ((j & 1) == 0)
-							lineRect.origin.x = MAX(upper.x, lower.x);
-						else {
-							lineRect.size.width = MIN(upper.x, lower.x) - lineRect.origin.x;
-							lineRect = NormalizedRect(lineRect);
+							if ((j & 1) == 0)
+								lineRect.origin.x = MAX(upper.x, lower.x);
+							else {
+								lineRect.size.width = MIN(upper.x, lower.x) - lineRect.origin.x;
+								lineRect = NormalizedRect(lineRect);
 
-							// if any corner of the rect is outside the path, chuck it
+								// if any corner of the rect is outside the path, chuck it
 
-							NSRect tr = NSInsetRect(lineRect, 1, 1);
-							NSPoint tp = NSMakePoint(NSMinX(tr), NSMinY(tr));
+								NSRect tr = NSInsetRect(lineRect, 1, 1);
+								NSPoint tp = NSMakePoint(NSMinX(tr), NSMinY(tr));
 
-							if (![self containsPoint:tp])
-								continue;
+								if (![self containsPoint:tp])
+									continue;
 
-							tp = NSMakePoint(NSMaxX(tr), NSMinY(tr));
-							if (![self containsPoint:tp])
-								continue;
+								tp = NSMakePoint(NSMaxX(tr), NSMinY(tr));
+								if (![self containsPoint:tp])
+									continue;
 
-							tp = NSMakePoint(NSMaxX(tr), NSMaxY(tr));
-							if (![self containsPoint:tp])
-								continue;
+								tp = NSMakePoint(NSMaxX(tr), NSMaxY(tr));
+								if (![self containsPoint:tp])
+									continue;
 
-							tp = NSMakePoint(NSMinX(tr), NSMaxY(tr));
-							if (![self containsPoint:tp])
-								continue;
+								tp = NSMakePoint(NSMinX(tr), NSMaxY(tr));
+								if (![self containsPoint:tp])
+									continue;
 
-							[result addObject:[NSValue valueWithRect:lineRect]];
+								[result addObject:[NSValue valueWithRect:lineRect]];
+							}
 						}
-					}
 
-					previousLine = currentLine;
+						previousLine = currentLine;
+					}
 				}
 			}
 		}
-		[pool release];
 	}
 
 	return result;

--- a/framework/Code/NSColor+DKAdditions.h
+++ b/framework/Code/NSColor+DKAdditions.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSColor+DKAdditions.m
+++ b/framework/Code/NSColor+DKAdditions.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSColor+DKAdditions.h"
@@ -477,8 +477,7 @@
 	hg = (NSInteger)floor(g * 255.0f);
 	hb = (NSInteger)floor(b * 255.0f);
 
-#warning 64BIT: Check formatting arguments
-	NSString* s = [NSString stringWithFormat:@"#%02X%02X%02X", hr, hg, hb];
+	NSString* s = [NSString stringWithFormat:@"#%02lX%02lX%02lX", (long)hr, (long)hg, (long)hb];
 
 	return s;
 }

--- a/framework/Code/NSDictionary+DeepCopy.h
+++ b/framework/Code/NSDictionary+DeepCopy.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSDictionary+DeepCopy.m
+++ b/framework/Code/NSDictionary+DeepCopy.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSDictionary+DeepCopy.h"

--- a/framework/Code/NSImage+DKAdditions.h
+++ b/framework/Code/NSImage+DKAdditions.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSImage+DKAdditions.m
+++ b/framework/Code/NSImage+DKAdditions.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSImage+DKAdditions.h"

--- a/framework/Code/NSMutableArray+DKAdditions.h
+++ b/framework/Code/NSMutableArray+DKAdditions.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSMutableArray+DKAdditions.m
+++ b/framework/Code/NSMutableArray+DKAdditions.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSMutableArray+DKAdditions.h"

--- a/framework/Code/NSObject+GraphicsAttributes.h
+++ b/framework/Code/NSObject+GraphicsAttributes.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSObject+GraphicsAttributes.m
+++ b/framework/Code/NSObject+GraphicsAttributes.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSObject+GraphicsAttributes.h"

--- a/framework/Code/NSObject+StringValue.h
+++ b/framework/Code/NSObject+StringValue.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSObject+StringValue.m
+++ b/framework/Code/NSObject+StringValue.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSObject+StringValue.h"
@@ -17,8 +17,7 @@
 
 - (NSString*)address
 {
-#warning 64BIT: Check formatting arguments
-	return [NSString stringWithFormat:@"0x%X", self];
+	return [NSString stringWithFormat:@"%p", self];
 }
 
 @end
@@ -74,7 +73,6 @@
 
 	for (i = 0; i < [self count]; ++i) {
 		object = [self objectAtIndex:i];
-#warning 64BIT: Inspect use of long
 		[sv appendString:[NSString stringWithFormat:@"%ld: %@\n", (long)i, [object stringValue]]];
 	}
 

--- a/framework/Code/NSShadow+Scaling.h
+++ b/framework/Code/NSShadow+Scaling.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSShadow+Scaling.m
+++ b/framework/Code/NSShadow+Scaling.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSShadow+Scaling.h"

--- a/framework/Code/NSString+DKAdditions.h
+++ b/framework/Code/NSString+DKAdditions.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/NSString+DKAdditions.m
+++ b/framework/Code/NSString+DKAdditions.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "NSString+DKAdditions.h"

--- a/framework/Code/Omni/NSBezierPath-OAExtensions.h
+++ b/framework/Code/Omni/NSBezierPath-OAExtensions.h
@@ -168,7 +168,7 @@ void		_parameterizeCurve(NSPoint *coefficients, NSPoint startPoint, NSPoint endP
 - (BOOL)	_curvedIntersection:(CGFloat *) length time:(CGFloat *)time curve:(NSPoint *)c line:(NSPoint *)a;
 
 - (BOOL)	_curvedLineHit:(NSPoint) point startPoint:(NSPoint)startPoint endPoint:(NSPoint)endPoint controlPoint1:(NSPoint)controlPoint1 controlPoint2:(NSPoint)controlPoint2 position:(CGFloat *)position padding:(CGFloat)padding;
-- (BOOL)	_straightLineIntersection:(CGFloat *) length time:(CGFloat *)time segment:(NSPoint *)s line:(NSPoint *)l;
+- (BOOL)	_straightLineIntersection:(CGFloat *) length time:(CGFloat *)time segment:(NSPoint *)s line:(const NSPoint *)l;
 - (BOOL)	_straightLineHit:(NSPoint) startPoint :(NSPoint)endPoint :(NSPoint)point  :(CGFloat *)position padding:(CGFloat)padding;
 - (NSInteger)		_segmentHitByPoint:(NSPoint) point position:(CGFloat *)position padding:(CGFloat)padding;
 - (NSPoint)	_endPointForSegment:(NSInteger) i;

--- a/framework/Code/Omni/NSBezierPath-OAExtensions.m
+++ b/framework/Code/Omni/NSBezierPath-OAExtensions.m
@@ -103,7 +103,6 @@ static struct pointInfo getLinePoint(const NSPoint *a, CGFloat position) {
         if (element == NSMoveToBezierPathElement)
             return points[0];
         else
-#warning 64BIT: Inspect use of long
             [NSException raise:NSInternalInconsistencyException format:@"Segment %ld has no currentpoint", (long)i];
     }
     
@@ -116,7 +115,6 @@ static struct pointInfo getLinePoint(const NSPoint *a, CGFloat position) {
         case NSLineToBezierPathElement:
             return points[0];
         default:
-#warning 64BIT: Inspect use of long
             [NSException raise:NSInternalInconsistencyException format:@"Segment %ld has no currentpoint", (long)i];
     }
     
@@ -402,16 +400,15 @@ static BOOL subsequent(struct OABezierPathIntersectionHalf *one, struct OABezier
 
 - (struct OABezierPathIntersectionList)allIntersectionsWithPath:(NSBezierPath *)other
 {
-    NSUInteger intersectionCount, listSize;
+	NSUInteger intersectionCount = 0;
+	NSUInteger listSize = 16;
     OABezierPathIntersection *intersections;
 	subpathWalkingState selfIter;
     
     if (!initializeSubpathWalkingState(&selfIter, self, 0, NO))
         return (struct OABezierPathIntersectionList){ 0, NULL };
-    
-    intersectionCount = 0;
-#warning 64BIT: Inspect use of sizeof
-    intersections = malloc(sizeof(*intersections) * (listSize = 16));
+	
+    intersections = malloc(sizeof(*intersections) * listSize);
     
     while(nextSubpathElement(&selfIter)) {
         subpathWalkingState otherIter;
@@ -498,14 +495,12 @@ static BOOL subsequent(struct OABezierPathIntersectionHalf *one, struct OABezier
                     if (i.leftParameterDistance < EPSILON &&
                         i.leftParameter <= (WEPSILON) &&
                         i.rightParameter >= (1 - WEPSILON)) {
-#warning 64BIT: Inspect use of sizeof
                         memmove(segmentIntersections+1, segmentIntersections, sizeof(*segmentIntersections)*(--intersectionsFound));
                     }
                 }
             }
                     
             if (intersectionsFound + intersectionCount > listSize) {
-#warning 64BIT: Inspect use of sizeof
                 intersections = realloc(intersections, sizeof(*intersections) * (listSize += (listSize >> 1)));
             }
             
@@ -523,7 +518,6 @@ static BOOL subsequent(struct OABezierPathIntersectionHalf *one, struct OABezier
                 
                 // Make room, if necessary
                 if (insertionPoint < intersectionCount)
-#warning 64BIT: Inspect use of sizeof
                     memmove(&(intersections[insertionPoint+1]), &(intersections[insertionPoint]), sizeof(*intersections)*(intersectionCount-insertionPoint));
                 if (insertionPoint < earliestInsertionPoint)
                     earliestInsertionPoint = insertionPoint;
@@ -541,7 +535,6 @@ static BOOL subsequent(struct OABezierPathIntersectionHalf *one, struct OABezier
     }
     
     if (listSize - intersectionCount > 8)
-#warning 64BIT: Inspect use of sizeof
         intersections = realloc(intersections, sizeof(*intersections) * (listSize = intersectionCount));
 
     return (struct OABezierPathIntersectionList){ intersectionCount, intersections };
@@ -920,7 +913,6 @@ void splitBezierCurveTo(const NSPoint *c, CGFloat t, NSPoint *l, NSPoint *r)
                     break;
             }
             if (element != NSMoveToBezierPathElement)
-#warning 64BIT: Inspect use of long
                 [NSException raise:NSInternalInconsistencyException format:@"Segment %ld has no preceding moveto", (long)pos.segment];
             /* FALL THROUGH to lineto cxase */
         }
@@ -938,8 +930,6 @@ void splitBezierCurveTo(const NSPoint *c, CGFloat t, NSPoint *l, NSPoint *r)
 				break;
    }
     
-#warning 64BIT: Inspect use of long
-#warning 64BIT: Inspect use of long
     [NSException raise:NSInternalInconsistencyException format:@"Segment %ld has unexpected element type %ld", (long)pos.segment, (long)element];
     return (NSPoint){ nanf(""), nanf("") };
 }
@@ -1142,8 +1132,7 @@ static double subpathElementLength( subpathWalkingState *iter, double errorBudge
         double *lengths;
         double totalLength;
         NSInteger filledLengths, curLength;
-        
-#warning 64BIT: Inspect use of sizeof
+		
         lengths = malloc((cursor.elementCount+1) * sizeof(lengths));
         filledLengths = 0;
         totalLength = 0;
@@ -1229,7 +1218,6 @@ static NSInteger compareFloat(const void *a_, const void *b_)
     /* We can have problems if the "probe" line we use is collinear with a path segment, or a couple of other similar cases. To avoid those, we choose a y-value for our horizontal probe line that goes midway between the largest gap between any points' y-coordinates. */
     
     /* Make a list o all elts' y-coordinates, sort it, and run through the list looking for the widest gap */
-#warning 64BIT: Inspect use of sizeof
     CGFloat *yCoordinates = malloc(sizeof(*yCoordinates) * elementCount);
     coordinateCount = 0;
     for(elementIndex = 0; elementIndex < elementCount; elementIndex ++) {
@@ -1243,7 +1231,6 @@ static NSInteger compareFloat(const void *a_, const void *b_)
     }
     if (coordinateCount < 2)
         return YES;  // degenerate path
-#warning 64BIT: Inspect use of sizeof
     qsort(yCoordinates, coordinateCount, sizeof(*yCoordinates), compareFloat);
     
     CGFloat bestGapSize, bestGapMidpoint;
@@ -1412,7 +1399,6 @@ static NSInteger compareFloat(const void *a_, const void *b_)
 
 static inline NSUInteger _spinLeft(NSUInteger number, NSUInteger spinLeftBitCount)
 {
-#warning 64BIT: Inspect use of sizeof
     const NSUInteger bitsPerUnsignedInt = sizeof(NSUInteger) * 8;
     NSUInteger leftmostBits = number >> (bitsPerUnsignedInt - spinLeftBitCount);
     return (number << spinLeftBitCount) | leftmostBits;
@@ -1498,13 +1484,13 @@ static inline BOOL pdrangeCoversPDrange(double rstart, double rlength, double r2
     return (rstart <= r2start) && (rlength - r2length >= r2start - rstart);
 }
 
-static inline BOOL drangeCoversDrange(double rstart, double rlength, double r2start, double r2length)
-{
-    if (r2length < 0)
-        return drangeCoversPDrange(rstart, rlength, r2start + r2length, - r2length);
-    else
-        return drangeCoversPDrange(rstart, rlength, r2start, r2length);
-}
+//static inline BOOL drangeCoversDrange(double rstart, double rlength, double r2start, double r2length)
+//{
+//    if (r2length < 0)
+//        return drangeCoversPDrange(rstart, rlength, r2start + r2length, - r2length);
+//    else
+//        return drangeCoversPDrange(rstart, rlength, r2start, r2length);
+//}
 
 static BOOL drangeIntersectsDrange(double r1start, double r1length, double r2start, double r2length)
 {
@@ -1530,32 +1516,31 @@ static inline void combinePDranges(double *r, double *len, double r1, double r1l
     *len = MAX(newDL, newDR);
 }
 
-static inline void combineNDranges(double *r, double *len, double r1, double r1len, double r2, double r2len)
-{
-    double newP, newDL, newDR;
-    
-    if (r1 >= r2)
-        newP = r1, newDL = r1len, newDR = r2len + (r2 - newP);
-    else
-        newP = r2, newDL = r2len, newDR = r1len + (r1 - newP);
-    
-    *r = newP;
-    *len = MIN(newDL, newDR);
-}
+//static inline void combineNDranges(double *r, double *len, double r1, double r1len, double r2, double r2len)
+//{
+//    double newP, newDL, newDR;
+//    
+//    if (r1 >= r2)
+//        newP = r1, newDL = r1len, newDR = r2len + (r2 - newP);
+//    else
+//        newP = r2, newDL = r2len, newDR = r1len + (r1 - newP);
+//    
+//    *r = newP;
+//    *len = MIN(newDL, newDR);
+//}
 
-static inline void combineDranges(double *r, double *len, double r1, double r1len, double r2, double r2len)
-{
-    if(r1len >= 0)
-        combinePDranges(r, len, r1, r1len, r2, r2len);
-    else
-        combineNDranges(r, len, r1, r1len, r2, r2len);
-}
+//static inline void combineDranges(double *r, double *len, double r1, double r1len, double r2, double r2len)
+//{
+//    if(r1len >= 0)
+//        combinePDranges(r, len, r1, r1len, r2, r2len);
+//    else
+//        combineNDranges(r, len, r1, r1len, r2, r2len);
+//}
 
 #define CLAMP(x, low, high) do{ if((x)<low) (x)=low; else if((x)>high) (x)=high; }while(0)
 
 NSString *_roundedStringForPoint(NSPoint point)
 {
-#warning 64BIT: Check formatting arguments
     return [NSString stringWithFormat:@"{%.5f,%.5f}", point.x, point.y];
 }
 
@@ -1637,7 +1622,6 @@ static inline BOOL looseCubicExceedsBounds(const double *c,
     if (p3 < yMin || p3 > yMax)
         return YES;
 
-#warning 64BIT: Check formatting arguments
     CDB(NSLog(@"Loose bounds(%g %g) --> %g %g %g %g", tMin, tMax, p0, p1, p2, p3);)
     
     return NO;
@@ -1819,13 +1803,13 @@ static inline double evaluateCubicSecondDerivative(const double *c, double x)
     return  6 * c[3] * x + 2 * c[2] ;
 }
 
-static inline OAdPoint evaluateCubicPt(const OAdPoint *c, double t)
-{
-    return (OAdPoint){
-        (( c[3].x * t + c[2].x ) * t + c[1].x ) * t + c[0].x,
-        (( c[3].y * t + c[2].y ) * t + c[1].y ) * t + c[0].y
-    };
-}
+//static inline OAdPoint evaluateCubicPt(const OAdPoint *c, double t)
+//{
+//    return (OAdPoint){
+//        (( c[3].x * t + c[2].x ) * t + c[1].x ) * t + c[0].x,
+//        (( c[3].y * t + c[2].y ) * t + c[1].y ) * t + c[0].y
+//    };
+//}
 
 static inline OAdPoint evaluateCubicDerivativePt(const NSPoint *c, double t)
 {
@@ -2116,15 +2100,12 @@ static inline enum OAIntersectionAspect lineAspect(OAdPoint tangent, double offs
 {
     double cross = tangent.x * offsetY - tangent.y * offsetX;
     if (cross > 0) {
-#warning 64BIT: Check formatting arguments
         CDB(printf(" right aspect from dx=%g dy=%g\n", offsetX, offsetY);)
         return intersectionEntryRight;
     } else if (cross < 0) {
-#warning 64BIT: Check formatting arguments
         CDB(printf(" left  aspect from dx=%g dy=%g\n", offsetX, offsetY);)
         return intersectionEntryLeft;
     } else {
-#warning 64BIT: Check formatting arguments
         CDB(printf(" along aspect from dx=%g dy=%g\n", offsetX, offsetY);)
         return intersectionEntryAt;
     }
@@ -2304,7 +2285,6 @@ static NSInteger mergeSortIntersectionInfo(struct intersectionInfo *buf, NSInteg
             // NSLog(@"Dup %g %g %g %g", (buf[0].leftParameter - buf[count1].leftParameter), (buf[0].rightParameter - buf[count1].rightParameter), (buf[0].leftParameterDistance - buf[count1].leftParameterDistance), (buf[0].rightParameterDistance - buf[count1].rightParameterDistance));
             // Simply drop the element at buf[count1].
             // TODO: Merge the ranges if the distances are nonzero?
-#warning 64BIT: Inspect use of sizeof
             memmove(&(buf[count1]), &(buf[count1+1]), sizeof(*buf)*(count1-1));
             count2 --;
         } else if (buf[0].leftParameter <= buf[count1].leftParameter) {
@@ -2315,7 +2295,6 @@ static NSInteger mergeSortIntersectionInfo(struct intersectionInfo *buf, NSInteg
         } else {
             // Copy the element at buf[count1] into the output buffer (must move the rest of the left-side entries up one, to make room)
             struct intersectionInfo tmp = buf[count1];
-#warning 64BIT: Inspect use of sizeof
             memmove(&(buf[1]), &(buf[0]), sizeof(*buf) * count1);
             buf[0] = tmp;
             count2 --;
@@ -2459,7 +2438,6 @@ static BOOL extendGrazingIntersection(const NSPoint *c1coeff, const NSPoint *c2c
     
     newStart = TsharedMin * leftRate + i->rightParameter;
     newEnd = TsharedMax * leftRate + i->rightParameter;
-#warning 64BIT: Check formatting arguments
     CDB(NSLog(@"T'(%g %g) --> t_right(%g %g) or 1+(%g %g)", TsharedMin, TsharedMax, newStart, newEnd, newStart-1, newEnd-1);)
     OBASSERT(newStart >= 0-EPSILON);
     OBASSERT(newStart <= 1+EPSILON);
@@ -2478,7 +2456,6 @@ static BOOL extendGrazingIntersection(const NSPoint *c1coeff, const NSPoint *c2c
         i->leftExitAspect = - entryAspect;
     }
 
-#warning 64BIT: Check formatting arguments
     CDB(NSLog(@"Grazing extension: t'=(%g ... %g) --> left=%g%+g  right=%g%+g  (was left=%g right=%g) aspects %s-%s",
               TsharedMin, TsharedMax,
               i->leftParameter, i->leftParameterDistance, i->rightParameter, i->rightParameterDistance,
@@ -2571,8 +2548,7 @@ static NSInteger intersectionsBetweenCurveAndCurveMonotonic(const NSPoint *c1coe
     
     error_bound_left = ( vecmag(left[2].x+left[3].x, left[2].y+left[3].y) + vecmag(left[3].x, left[3].y) ) / 4;
     error_bound_right = ( vecmag(right[2].x+right[3].x, right[2].y+right[3].y) + vecmag(right[3].x, right[3].y) ) / 4;
-    
-#warning 64BIT: Check formatting arguments
+	
     CDB(printf("errbs=(%g,%g)", error_bound_left, error_bound_right);)
     
     if (error_bound_left < FLATNESS || error_bound_right < FLATNESS) {
@@ -2587,7 +2563,6 @@ static NSInteger intersectionsBetweenCurveAndCurveMonotonic(const NSPoint *c1coe
             l2[1].x = right[1].x + right[2].x + right[3].x;
             l2[1].y = right[1].y + right[2].y + right[3].y;
             found = intersectionsBetweenCurveAndLine(left, l2, results);
-#warning 64BIT: Check formatting arguments
             CDB(printf(" found %d via right linearization", found);)
         } else {
             // Same as above, but the left-hand curve was flatter.
@@ -2597,13 +2572,11 @@ static NSInteger intersectionsBetweenCurveAndCurveMonotonic(const NSPoint *c1coe
             found = intersectionsBetweenCurveAndLine(right, l2, results);
             for(fixup = 0; fixup < found; fixup++)
                 reverseSenseOfIntersection(&(results[fixup]));
-#warning 64BIT: Check formatting arguments
             CDB(printf(" found %d via left  linearization", found);)
         }
     
         // TODO: We could probably do a newton-raphson step here to get a few more digits of accuracy?
 
-#warning 64BIT: Check formatting arguments
         CDB(printf(": (%g%+g, %g%+g)\n", l2[0].x, l2[1].x, l2[0].y, l2[1].y);)
         
         
@@ -2646,8 +2619,6 @@ static NSInteger intersectionsBetweenCurveAndCurveMonotonic(const NSPoint *c1coe
     
     for(qq = 0; qq < indent; qq++)
         putchar(' ');
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
     printf("found %d %d %d %d -> %d %d -> %d\n", f0, fh0, foundLow, foundHigh, foundFirstHalf, foundSecondHalf, foundTotal);
 #endif
     
@@ -2701,11 +2672,7 @@ static NSInteger computeCurveSegments(const NSPoint *coeff, struct curveSegment 
         NSInteger q;
         NSMutableString *s = [NSMutableString string];
         for(q = 0; q < segcount; q++)
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
             [s appendFormat:@"  %g%+g", segments[q].start, segments[q].size];
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
         NSLog(@"Curve segments(%d): %@", segcount, s);
     }
 #endif
@@ -2726,8 +2693,6 @@ static NSInteger coalesceExtendedIntersections(struct intersectionInfo *results,
                 drangeIntersectsDrange(results[i].rightParameter, results[i].rightParameterDistance, results[j].rightParameter, results[j].rightParameterDistance) &&
                 signbit(results[i].rightParameterDistance) == signbit(results[j].rightParameterDistance)) {
                 
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
                 CDB(printf("combining %d:[%g%+g %g%+g] %s-%s and %d:[%g%+g %g%+g] %s-%s ",
                            i, results[i].leftParameter, results[i].leftParameterDistance, results[i].rightParameter, results[i].rightParameterDistance,
                            straspect(results[i].leftEntryAspect), straspect(results[i].leftExitAspect),
@@ -2770,11 +2735,8 @@ static NSInteger coalesceExtendedIntersections(struct intersectionInfo *results,
                 results[i].rightParameter = newStart;
                 results[i].rightParameterDistance = newEnd - newStart;
                 
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
                 CDB(printf("into [%g%+g %g%+g] %s-%s\n", results[i].leftParameter, results[i].leftParameterDistance, results[i].rightParameter, results[i].rightParameterDistance, straspect(results[i].leftEntryAspect), straspect(results[i].leftExitAspect));)
                     
-#warning 64BIT: Inspect use of sizeof
                 memmove(&(results[j]), &(results[j+1]), sizeof(*results) * (found - (j+1)));
                 found --;
                 j --;

--- a/framework/Code/TestBSPStorage.h
+++ b/framework/Code/TestBSPStorage.h
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <SenTestingKit/SenTestingKit.h>

--- a/framework/Code/TestBSPStorage.m
+++ b/framework/Code/TestBSPStorage.m
@@ -1,7 +1,7 @@
 /**
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "TestBSPStorage.h"
@@ -401,67 +401,67 @@ static NSUInteger randomUnsigned(NSUInteger minVal, NSUInteger maxVal)
 	NSRect retrievalRect;
 
 	for (i = 0; i < NUMBER_OF_RETRIEVAL_TESTS; ++i) {
-		NSAutoreleasePool* pool = [NSAutoreleasePool new];
+		@autoreleasepool {
 
-		l = randomFloat(0, canvasSize.width);
-		t = randomFloat(0, canvasSize.height);
-		w = randomFloat(0, canvasSize.width / 2);
-		h = randomFloat(0, canvasSize.height / 2);
-		retrievalRect = NSMakeRect(l, t, w, h);
+			l = randomFloat(0, canvasSize.width);
+			t = randomFloat(0, canvasSize.height);
+			w = randomFloat(0, canvasSize.width / 2);
+			h = randomFloat(0, canvasSize.height / 2);
+			retrievalRect = NSMakeRect(l, t, w, h);
 
-		// ensure the retrieval rect stays within the bounds of the canvas
+			// ensure the retrieval rect stays within the bounds of the canvas
 
-		retrievalRect = NSIntersectionRect(retrievalRect, NSMakeRect(0, 0, canvasSize.width, canvasSize.height));
+			retrievalRect = NSIntersectionRect(retrievalRect, NSMakeRect(0, 0, canvasSize.width, canvasSize.height));
 
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
-		NSLog(@"retrieval test %d, rect = %@", i, NSStringFromRect(retrievalRect));
+	#warning 64BIT: Check formatting arguments
+	#warning 64BIT: Check formatting arguments
+			NSLog(@"retrieval test %d, rect = %@", i, NSStringFromRect(retrievalRect));
 
-		// move some of the objects to random new locations for some of the tests
+			// move some of the objects to random new locations for some of the tests
 
-		if ((i % MOVE_OBJECTS_FOR_TEST_MOD) == 0 && i > 0) {
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
-			NSLog(@"repositioning objects for test #%d", i);
-			[self repositioningTest:storage
-						 canvasSize:canvasSize];
+			if ((i % MOVE_OBJECTS_FOR_TEST_MOD) == 0 && i > 0) {
+	#warning 64BIT: Check formatting arguments
+	#warning 64BIT: Check formatting arguments
+				NSLog(@"repositioning objects for test #%d", i);
+				[self repositioningTest:storage
+							 canvasSize:canvasSize];
+			}
+
+			[bruteForceSearchResults removeAllObjects];
+
+			// do the brute force search first. These should be in the right z-order.
+
+			NSEnumerator* iter = [objects objectEnumerator];
+			while ((tso = [iter nextObject])) {
+				if (NSIntersectsRect(retrievalRect, [tso bounds]))
+					[bruteForceSearchResults addObject:tso];
+			}
+
+			// retrieve what should be the same objects the clever way:
+
+			bspResults = [storage objectsIntersectingRect:retrievalRect
+												   inView:nil
+												  options:0];
+
+			// now check they are what they should be:
+
+			STAssertEquals([bspResults count], [bruteForceSearchResults count], @"object counts do not match, brute force = %d, bsp = %d", [bruteForceSearchResults count], [bspResults count]);
+
+			// check each object is the same
+
+			NSUInteger j, k = [bspResults count];
+
+			for (j = 0; j < k; ++j) {
+				id<DKStorableObject> bruteObject;
+
+				bruteObject = [bruteForceSearchResults objectAtIndex:j];
+				tso = [bspResults objectAtIndex:j];
+
+				STAssertEqualObjects(bruteObject, tso, @"objects at index %d do not match - bf = %@, bsp = %@", j, bruteObject, tso);
+				STAssertFalse([tso isMarked], @"retrieved object still has marked flag set, index = %d", j);
+			}
+
 		}
-
-		[bruteForceSearchResults removeAllObjects];
-
-		// do the brute force search first. These should be in the right z-order.
-
-		NSEnumerator* iter = [objects objectEnumerator];
-		while ((tso = [iter nextObject])) {
-			if (NSIntersectsRect(retrievalRect, [tso bounds]))
-				[bruteForceSearchResults addObject:tso];
-		}
-
-		// retrieve what should be the same objects the clever way:
-
-		bspResults = [storage objectsIntersectingRect:retrievalRect
-											   inView:nil
-											  options:0];
-
-		// now check they are what they should be:
-
-		STAssertEquals([bspResults count], [bruteForceSearchResults count], @"object counts do not match, brute force = %d, bsp = %d", [bruteForceSearchResults count], [bspResults count]);
-
-		// check each object is the same
-
-		NSUInteger j, k = [bspResults count];
-
-		for (j = 0; j < k; ++j) {
-			id<DKStorableObject> bruteObject;
-
-			bruteObject = [bruteForceSearchResults objectAtIndex:j];
-			tso = [bspResults objectAtIndex:j];
-
-			STAssertEqualObjects(bruteObject, tso, @"objects at index %d do not match - bf = %@, bsp = %@", j, bruteObject, tso);
-			STAssertFalse([tso isMarked], @"retrieved object still has marked flag set, index = %d", j);
-		}
-
-		[pool drain];
 	}
 
 	// a final retrieval test - if the retrieval rect is the whole canvas, number returned should equal entire object count
@@ -485,59 +485,59 @@ static NSUInteger randomUnsigned(NSUInteger minVal, NSUInteger maxVal)
 	CGFloat t, l;
 
 	for (i = 0; i < NUMBER_OF_RETRIEVAL_TESTS; ++i) {
-		NSAutoreleasePool* pool = [NSAutoreleasePool new];
+		@autoreleasepool {
 
-		l = randomFloat(0, canvasSize.width);
-		t = randomFloat(0, canvasSize.height);
-		NSPoint retrievalPoint = NSMakePoint(l, t);
+			l = randomFloat(0, canvasSize.width);
+			t = randomFloat(0, canvasSize.height);
+			NSPoint retrievalPoint = NSMakePoint(l, t);
 
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
-		NSLog(@"point retrieval test %d, pt = %@", i, NSStringFromPoint(retrievalPoint));
+	#warning 64BIT: Check formatting arguments
+	#warning 64BIT: Check formatting arguments
+			NSLog(@"point retrieval test %d, pt = %@", i, NSStringFromPoint(retrievalPoint));
 
-		// move some of the objects to random new locations for some of the tests
+			// move some of the objects to random new locations for some of the tests
 
-		if ((i % MOVE_OBJECTS_FOR_TEST_MOD) == 0 && i > 0) {
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
-			NSLog(@"repositioning objects for test #%d", i);
-			[self repositioningTest:storage
-						 canvasSize:canvasSize];
+			if ((i % MOVE_OBJECTS_FOR_TEST_MOD) == 0 && i > 0) {
+	#warning 64BIT: Check formatting arguments
+	#warning 64BIT: Check formatting arguments
+				NSLog(@"repositioning objects for test #%d", i);
+				[self repositioningTest:storage
+							 canvasSize:canvasSize];
+			}
+
+			[bruteForceSearchResults removeAllObjects];
+
+			// do the brute force search first. These should be in the right z-order.
+
+			NSEnumerator* iter = [objects objectEnumerator];
+			while ((tso = [iter nextObject])) {
+				if (NSPointInRect(retrievalPoint, [tso bounds]))
+					[bruteForceSearchResults addObject:tso];
+			}
+
+			// retrieve what should be the same objects the clever way:
+
+			NSArray* bspResults = [storage objectsContainingPoint:retrievalPoint];
+
+			// now check they are what they should be:
+
+			STAssertEquals([bspResults count], [bruteForceSearchResults count], @"object counts do not match, brute force = %d, bsp = %d", [bruteForceSearchResults count], [bspResults count]);
+
+			// check each object is the same
+
+			NSUInteger j, k = [bspResults count];
+
+			for (j = 0; j < k; ++j) {
+				id<DKStorableObject> bruteObject;
+
+				bruteObject = [bruteForceSearchResults objectAtIndex:j];
+				tso = [bspResults objectAtIndex:j];
+
+				STAssertEqualObjects(bruteObject, tso, @"objects at index %d do not match - bf = %@, bsp = %@", j, bruteObject, tso);
+				STAssertFalse([tso isMarked], @"retrieved object still has marked flag set, index = %d", j);
+			}
+
 		}
-
-		[bruteForceSearchResults removeAllObjects];
-
-		// do the brute force search first. These should be in the right z-order.
-
-		NSEnumerator* iter = [objects objectEnumerator];
-		while ((tso = [iter nextObject])) {
-			if (NSPointInRect(retrievalPoint, [tso bounds]))
-				[bruteForceSearchResults addObject:tso];
-		}
-
-		// retrieve what should be the same objects the clever way:
-
-		NSArray* bspResults = [storage objectsContainingPoint:retrievalPoint];
-
-		// now check they are what they should be:
-
-		STAssertEquals([bspResults count], [bruteForceSearchResults count], @"object counts do not match, brute force = %d, bsp = %d", [bruteForceSearchResults count], [bspResults count]);
-
-		// check each object is the same
-
-		NSUInteger j, k = [bspResults count];
-
-		for (j = 0; j < k; ++j) {
-			id<DKStorableObject> bruteObject;
-
-			bruteObject = [bruteForceSearchResults objectAtIndex:j];
-			tso = [bspResults objectAtIndex:j];
-
-			STAssertEqualObjects(bruteObject, tso, @"objects at index %d do not match - bf = %@, bsp = %@", j, bruteObject, tso);
-			STAssertFalse([tso isMarked], @"retrieved object still has marked flag set, index = %d", j);
-		}
-
-		[pool drain];
 	}
 
 	[bruteForceSearchResults release];
@@ -653,19 +653,19 @@ static NSUInteger randomUnsigned(NSUInteger minVal, NSUInteger maxVal)
 	NSUInteger foundCount = 0;
 
 	while ((tso = [iter nextObject])) {
-		NSAutoreleasePool* pool = [NSAutoreleasePool new];
-		NSEnumerator* leafEnum = [leaves objectEnumerator];
+		@autoreleasepool {
+			NSEnumerator* leafEnum = [leaves objectEnumerator];
 
-		while ((leafArray = [leafEnum nextObject])) {
-			if ([leafArray containsObject:tso]) {
-				foundCount++;
-				break;
+			while ((leafArray = [leafEnum nextObject])) {
+				if ([leafArray containsObject:tso]) {
+					foundCount++;
+					break;
+				}
 			}
-		}
-		STAssertNotNil([tso storage], @"a storage back-pointer was nil (%@)", tso);
-		STAssertEqualObjects([tso storage], storage, @"a storage back-pointer wasn't pointing to the storage (%@)", tso);
+			STAssertNotNil([tso storage], @"a storage back-pointer was nil (%@)", tso);
+			STAssertEqualObjects([tso storage], storage, @"a storage back-pointer wasn't pointing to the storage (%@)", tso);
 
-		[pool drain];
+		}
 	}
 
 	STAssertEquals(foundCount, [storage countOfObjects], @"number of objects in tree is not equal to number in linear storage, expected %d, got %d", [storage countOfObjects], foundCount);
@@ -677,23 +677,21 @@ static NSUInteger randomUnsigned(NSUInteger minVal, NSUInteger maxVal)
 		NSUInteger linIndex = 0;
 
 		while ((tso = [iter nextObject])) {
-			NSAutoreleasePool* pool = [NSAutoreleasePool new];
+			@autoreleasepool {
 
-			NSEnumerator* leafEnum = [leaves objectEnumerator];
-			BOOL found = NO;
+				NSEnumerator* leafEnum = [leaves objectEnumerator];
+				BOOL found = NO;
 
-			while ((leafArray = [leafEnum nextObject])) {
-				if ([leafArray containsObject:tso]) {
-					found = YES;
-					break;
+				while ((leafArray = [leafEnum nextObject])) {
+					if ([leafArray containsObject:tso]) {
+						found = YES;
+						break;
+					}
 				}
+
 			}
 
-			[pool drain];
-
 			if (!found) {
-#warning 64BIT: Check formatting arguments
-#warning 64BIT: Check formatting arguments
 				NSLog(@"first object not found in tree is: %@ (index = %d, bounds = %@, array index = %d)", tso, [tso index], NSStringFromRect([tso bounds]), linIndex);
 				break;
 			}
@@ -708,17 +706,17 @@ static NSUInteger randomUnsigned(NSUInteger minVal, NSUInteger maxVal)
 
 	iter = [leaves objectEnumerator];
 	while ((leafArray = [iter nextObject])) {
-		NSAutoreleasePool* pool = [NSAutoreleasePool new];
+		@autoreleasepool {
 
-		NSEnumerator* leafIter = [leafArray objectEnumerator];
-		while ((tso = [leafIter nextObject])) {
-			STAssertTrue([[storage objects] containsObject:tso], @"an object was present in the tree but not in the linear array: %@ (leaf index = %d)", tso, foundCount);
-			STAssertNotNil([tso storage], @"a storage back-pointer was nil (%@)", tso);
-			STAssertEquals([tso storage], storage, @"a storage back-pointer wasn't pointing to the storage");
+			NSEnumerator* leafIter = [leafArray objectEnumerator];
+			while ((tso = [leafIter nextObject])) {
+				STAssertTrue([[storage objects] containsObject:tso], @"an object was present in the tree but not in the linear array: %@ (leaf index = %d)", tso, foundCount);
+				STAssertNotNil([tso storage], @"a storage back-pointer was nil (%@)", tso);
+				STAssertEquals([tso storage], storage, @"a storage back-pointer wasn't pointing to the storage");
+			}
+			++foundCount;
+
 		}
-		++foundCount;
-
-		[pool drain];
 	}
 }
 

--- a/framework/Code/parser/DKEvaluator.h
+++ b/framework/Code/parser/DKEvaluator.h
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/parser/DKEvaluator.m
+++ b/framework/Code/parser/DKEvaluator.m
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKEvaluator.h"

--- a/framework/Code/parser/DKExpression.h
+++ b/framework/Code/parser/DKExpression.h
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Foundation/Foundation.h>

--- a/framework/Code/parser/DKExpression.m
+++ b/framework/Code/parser/DKExpression.m
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKExpression.h"

--- a/framework/Code/parser/DKParser.h
+++ b/framework/Code/parser/DKParser.h
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Foundation/Foundation.h>

--- a/framework/Code/parser/DKParser.m
+++ b/framework/Code/parser/DKParser.m
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKParser.h"

--- a/framework/Code/parser/DKScriptingAdditions.h
+++ b/framework/Code/parser/DKScriptingAdditions.h
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/parser/DKScriptingAdditions.m
+++ b/framework/Code/parser/DKScriptingAdditions.m
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKScriptingAdditions.h"

--- a/framework/Code/parser/DKSymbol.h
+++ b/framework/Code/parser/DKSymbol.h
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import <Cocoa/Cocoa.h>

--- a/framework/Code/parser/DKSymbol.m
+++ b/framework/Code/parser/DKSymbol.m
@@ -2,7 +2,7 @@
  @author Jason Jobe
  @author Contributions from the community; see CONTRIBUTORS.md
  @date 2005-2015
- @copyright GNU GPL3; see LICENSE
+ @copyright GNU LGPL3; see LICENSE
 */
 
 #import "DKSymbol.h"

--- a/framework/DrawKit.xcodeproj/project.pbxproj
+++ b/framework/DrawKit.xcodeproj/project.pbxproj
@@ -1377,7 +1377,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = DK;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = DrawKit;
 			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "DrawKit" */;
@@ -1682,7 +1682,8 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -1712,7 +1713,7 @@
 				GCC_WARN_UNUSED_VALUE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				SDKROOT = macosx;
 			};
 			name = Release;

--- a/framework/ThirdParty/CurveFit/matrix.cpp
+++ b/framework/ThirdParty/CurveFit/matrix.cpp
@@ -18,7 +18,11 @@
 #include "transforms.h"
 
 namespace Geom {
-
+	
+// Prototypes
+bool Translate_equalp(Matrix const &m0, Matrix const &m1, Geom::Coord const epsilon);
+Translate to_Translate(Matrix const &m);
+	
 /** Multiplies a Matrix with another.*/
 Matrix &Matrix::operator*=(Matrix const &o)
 {

--- a/framework/ThirdParty/CurveFit/point.cpp
+++ b/framework/ThirdParty/CurveFit/point.cpp
@@ -3,6 +3,7 @@
 #include "coord.h"
 #include "isnan.h" //temporary fix for isnan()
 #include "matrix.h"
+#include "float.h" // for DBL_MAX
 
 namespace Geom {
 
@@ -19,7 +20,7 @@ void Point::normalize() {
 	double len = hypot(_pt[0], _pt[1]);
 	if(len == 0) return;
 	if(isNaN(len)) return;
-	static double const inf = 1e400;
+	static double const inf = DBL_MAX;
 	if(len != inf) {
 		*this /= len;
 	} else {

--- a/framework/ThirdParty/LogEvent/LogEvent.m
+++ b/framework/ThirdParty/LogEvent/LogEvent.m
@@ -604,12 +604,12 @@ void LogLoggingState(NSArray* eventTypeNames)
 	return self; // Singleton's do not modify their retain count.
 }
 
-- (unsigned)retainCount
+- (NSUInteger)retainCount
 {
 	return UINT_MAX; // Denotes an object, such as a singleton, that cannot be released.
 }
 
-- (void)release
+- (oneway void)release
 {
 	// Singleton's do nothing.
 }


### PR DESCRIPTION
- Checked 64-bit warnings.
- Framework updated to target OS X 10.7; matches earlier documentation.
- Restored `curveFit:` in DKDrawablePath; had been removed due to licensing of GPC but this code appears unrelated.
- Removed calls to `setScalesWhenResized:`; deprecated in OS X 10.6.
- Fixed licence summary in source; LGPL3, not GPL3.
- Removed use of hardcoded font name in `DKKnob`.
- Added missing `doubleValue` and `integerValue` to `DKMetadataItem`.
- Restored `classIsImmediateSubclassOfClass` in `DKRuntimeHelper` thanks to http://www.cocoawithlove.com/2010/01/getting-subclasses-of-objective-c-class.html
- Replaced use of `NSAutoreleasePool` with `@autoreleasepool`.
- Wrapped Class keys used in NSDictionary within GCObservableObject as strings via `NSStringFromClass`.
- Removed code associated with BooleanOps; underlying code previously removed due to licensing conflict GPL vs LGPL.