### PR TITLE
reverse DKObjectOwnerLayer.hitTest objects order so the hitTest goes from the TOP DOWN …

### DIFF
--- a/Source/DKObjectOwnerLayer.m
+++ b/Source/DKObjectOwnerLayer.m
@@ -939,7 +939,7 @@ static DKLayerCacheOption sDefaultCacheOption = kDKLayerCacheNone;
 
 	LogEvent_(kUserEvent, @"hit-testing %lu objects; layer = %@; objects = %@", (unsigned long)[objects count], self, objects);
 
-	for (DKDrawableObject* o in objects) {
+	for (DKDrawableObject* o in [objects reverseObjectEnumerator]) {
 		partcode = [o hitPart:point];
 
 		if (partcode != kDKDrawingNoPart) {


### PR DESCRIPTION
… and selects image on top first (as opposed to bottom image first)