### PR TITLE
Add getPadding so the textEdit view aligns with textAdornments textRect

### DIFF
--- a/Source/DKImageAdornment.m
+++ b/Source/DKImageAdornment.m
@@ -55,7 +55,7 @@
 #pragma mark -
 - (void)setScale:(CGFloat)scale
 {
-	m_scale = LIMIT(scale, 0.2, 8.0);
+	m_scale = scale;//LIMIT(scale, 0.2, 8.0);
 }
 
 @synthesize scale = m_scale;

--- a/Source/DKTextAdornment.m
+++ b/Source/DKTextAdornment.m
@@ -1002,6 +1002,12 @@ static CGFloat s_maximumVerticalOffset = DEFAULT_BASELINE_OFFSET_MAX;
 
 		DKBezierTextContainer* bc = (id)[[lm textContainers] lastObject];
 
+		//setting the container size below should consider the m_textRect scale
+		//see textRect in DKImageAdornment
+		NSSize s = osize;
+		if (m_textRect.size.width != 0.0 || m_textRect.size.height != 0.0) {
+			s = NSMakeSize(s.width * m_textRect.size.width, s.height * m_textRect.size.height);
+		}
 		if ([self layoutMode] == kDKTextLayoutFlowedInPath) {
 			// if the text angle is rel to the object, the layout path should be the unrotated path
 			// so the the text is laid out unrotated, then transformed into place. So detect that case here
@@ -1019,14 +1025,14 @@ static CGFloat s_maximumVerticalOffset = DEFAULT_BASELINE_OFFSET_MAX;
 			textLayoutPath = [tfm transformBezierPath:textLayoutPath];
 
 			osize = [textLayoutPath bounds].size;
-			[bc setContainerSize:osize];
+			[bc setContainerSize:s];
 			[bc setBezierPath:textLayoutPath];
 		} else {
 			if ([self allowsTextToExtendHorizontally])
 				osize.width = 50000;
 
 			[bc setBezierPath:nil];
-			[bc setContainerSize:osize];
+			[bc setContainerSize:s];
 		}
 
 		NSRange glyphRange;

--- a/Source/DKTextShape.h
+++ b/Source/DKTextShape.h
@@ -224,6 +224,16 @@ Text shapes are shapes that draw text.
  */
 - (DKStyle*)syntheticStyle;
 
+//returns text padding so the textEdit view aligns with the textAdornment padding
+/** @brief Returns padding
+
+Sub classes may define a custom padding by setting the textAdornments textRect.
+We can use getPadding which has been overriden in sub class to make sure our
+textEdit view aligns with textAdornments textRect. Default returns 0.0
+@return a new style object
+*/
+-(CGFloat) getPadding;
+
 // text attributes - accesses the internal adornment object
 
 - (NSDictionary<NSAttributedStringKey, id>*)textAttributes;

--- a/Source/DKTextShape.m
+++ b/Source/DKTextShape.m
@@ -701,7 +701,7 @@ static NSString* sDefault_string = @"Double-click to edit this text";
 
 		CGFloat wScale = mTextAdornment.textRect.size.width;
 		CGFloat hScale = mTextAdornment.textRect.size.height;
-		DKStroke* bgStroke = [[self style] rendererWithName: @"backgroundStroke"];
+		DKStroke* bgStroke = [[self style] rendererWithName: @"background_stroke"];
 		NSRect br = NSMakeRect(self.logicalBounds.origin.x + bgStroke.width, self.logicalBounds.origin.y + bgStroke.width, self.size.width * wScale, self.size.height * hScale);
 		CGFloat offset = [[self textAdornment] verticalTextOffsetForObject:self];
 

--- a/Source/DKTextShape.m
+++ b/Source/DKTextShape.m
@@ -495,6 +495,11 @@ static NSString* sDefault_string = @"Double-click to edit this text";
 	}
 }
 
+-(CGFloat)getPadding
+{
+	return 0.0;
+}
+
 /** @brief Creates a style that is the current style + any text attributes
 
  A style which is the current style if it has text attributes, otherwise the current style with added text
@@ -701,8 +706,8 @@ static NSString* sDefault_string = @"Double-click to edit this text";
 
 		CGFloat wScale = mTextAdornment.textRect.size.width;
 		CGFloat hScale = mTextAdornment.textRect.size.height;
-		DKStroke* bgStroke = [[self style] rendererWithName: @"background_stroke"];
-		NSRect br = NSMakeRect(self.logicalBounds.origin.x + bgStroke.width, self.logicalBounds.origin.y + bgStroke.width, self.size.width * wScale, self.size.height * hScale);
+		CGFloat padding = [self getPadding];
+		NSRect br = NSMakeRect(self.logicalBounds.origin.x + padding, self.logicalBounds.origin.y + padding, self.size.width * wScale, self.size.height * hScale);
 		CGFloat offset = [[self textAdornment] verticalTextOffsetForObject:self];
 
 		br.origin.y += offset;

--- a/Source/DKTextShape.m
+++ b/Source/DKTextShape.m
@@ -699,7 +699,10 @@ static NSString* sDefault_string = @"Double-click to edit this text";
 		NSSize maxsize = [self maxSize];
 		NSSize minsize = [self minSize];
 
-		NSRect br = NSMakeRect(self.logicalBounds.origin.x, self.logicalBounds.origin.y, self.size.width, self.size.height);
+		CGFloat wScale = mTextAdornment.textRect.size.width;
+		CGFloat hScale = mTextAdornment.textRect.size.height;
+		DKStroke* bgStroke = [[self style] rendererWithName: @"backgroundStroke"];
+		NSRect br = NSMakeRect(self.logicalBounds.origin.x + bgStroke.width, self.logicalBounds.origin.y + bgStroke.width, self.size.width * wScale, self.size.height * hScale);
 		CGFloat offset = [[self textAdornment] verticalTextOffsetForObject:self];
 
 		br.origin.y += offset;


### PR DESCRIPTION
Sub classes may define a custom padding by setting the textAdornments textRect.
We can use getPadding which has been overriden in sub class to make sure our
textEdit view aligns with textAdornments textRect.